### PR TITLE
Improve fallback performance

### DIFF
--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -332,9 +332,10 @@ void d2s_buffered(double f, char* result) {
 
   // Step 2: Determine the interval of legal decimal representations.
   uint64_t mv = 4 * m2;
-//  uint64_t mp = 4 * m2 + 2;
   // Implicit bool -> int conversion. True is 1, false is 0.
   uint32_t mmShift = (m2 != (1ull << mantissaBits)) || (ieeeExponent <= 1);
+  // We would compute mp and mm like this:
+//  uint64_t mp = 4 * m2 + 2;
 //  uint64_t mm = mv - 1 - mmShift;
 
   // Step 3: Convert to a decimal power base using 128-bit arithmetic.
@@ -349,11 +350,6 @@ void d2s_buffered(double f, char* result) {
     int32_t k = POW5_INV_BITCOUNT + pow5bits(q) - 1;
     int32_t i = -e2 + q + k;
     vr = mulShiftAll(mv, POW5_INV_SPLIT[q], i, &vp, &vm, mmShift);
-//    vp = mulPow5InvDivPow2(mp, q, i);
-//    vm = mulPow5InvDivPow2(mv - 1 - mmShift, q, i);
-//    if (vm != x) {
-//      printf("%20" PRIu64 " %20" PRIu64 "\n", x, vm);
-//    }
 #ifdef DEBUG_RYU
     printf("%" PRIu64 " * 2^%d / 10^%d\n", mv, e2, q);
     printf("V+=%" PRIu64 "\nV =%" PRIu64 "\nV-=%" PRIu64 "\n", vp, vr, vm);
@@ -381,9 +377,6 @@ void d2s_buffered(double f, char* result) {
     int32_t k = pow5bits(i) - POW5_BITCOUNT;
     int32_t j = q - k;
     vr = mulShiftAll(mv, POW5_SPLIT[i], j, &vp, &vm, mmShift);
-//    vr = mulPow5divPow2(mv, i, j);
-//    vp = mulPow5divPow2(mv + 2, i, j);
-//    vm = mulPow5divPow2(mv - 1 - mmShift, i, j);
 #ifdef DEBUG_RYU
     printf("%" PRIu64 " * 5^%d / 10^%d\n", mv, -e2, q);
     printf("%d %d %d %d\n", q, i, k, j);

--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -177,21 +177,21 @@ static inline uint64_t mulShift(uint64_t m, uint64_t* mul, int32_t j) {
 
 static inline uint64_t mulShiftAll(
     uint64_t m, uint64_t* mul, int32_t j, uint64_t* vp, uint64_t* vm, uint32_t mmShift) {
-  m <<= 2;
-  uint128_t b0 = ((uint128_t) m) * mul[0]; // 0
-  uint128_t b2 = ((uint128_t) m) * mul[1]; // 64
-
-  uint128_t hi = (b0 >> 64) + b2;
-  uint128_t lo = b0 & 0xffffffffffffffffull;
-  uint128_t factor = (((uint128_t) mul[1]) << 64) + mul[0];
-  uint128_t vpLo = lo + (factor << 1);
-  *vp = (uint64_t) ((hi + (vpLo >> 64)) >> (j - 64));
-  uint128_t vmLo = lo - (factor << mmShift);
-  *vm = (uint64_t) ((hi + (vmLo >> 64) - (((uint128_t) 1ull) << 64)) >> (j - 64));
-  return (uint64_t) (hi >> (j - 64));
-  // *vp = mulShift(4 * m + 2, mul, j);
-  // *vm = mulShift(4 * m - 1 - mmShift, mul, j);
-  // return mulShift(4 * m, mul, j);
+//  m <<= 2;
+//  uint128_t b0 = ((uint128_t) m) * mul[0]; // 0
+//  uint128_t b2 = ((uint128_t) m) * mul[1]; // 64
+//
+//  uint128_t hi = (b0 >> 64) + b2;
+//  uint128_t lo = b0 & 0xffffffffffffffffull;
+//  uint128_t factor = (((uint128_t) mul[1]) << 64) + mul[0];
+//  uint128_t vpLo = lo + (factor << 1);
+//  *vp = (uint64_t) ((hi + (vpLo >> 64)) >> (j - 64));
+//  uint128_t vmLo = lo - (factor << mmShift);
+//  *vm = (uint64_t) ((hi + (vmLo >> 64) - (((uint128_t) 1ull) << 64)) >> (j - 64));
+//  return (uint64_t) (hi >> (j - 64));
+  *vp = mulShift(4 * m + 2, mul, j);
+  *vm = mulShift(4 * m - 1 - mmShift, mul, j);
+  return mulShift(4 * m, mul, j);
 }
 
 #elif defined(HAS_64_BIT_INTRINSICS)

--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -234,26 +234,22 @@ static inline uint64_t shiftright128(uint64_t lo, uint64_t hi, uint64_t dist) {
 
 #endif // HAS_64_BIT_INTRINSICS
 
-static inline uint64_t mulPow5InvDivPow2(uint64_t m, int32_t i, int32_t j) {
+static inline uint64_t mulShift(uint64_t m, uint64_t* mul, int32_t j) {
   // m is maximum 55 bits
-  uint64_t high1;                                           // 128
-  uint64_t low1 = umul128(m, POW5_INV_SPLIT[i][1], &high1); // 64
-  uint64_t high0;                                           // 64
-  umul128(m, POW5_INV_SPLIT[i][0], &high0);                 // 0
+  uint64_t high1;                             // 128
+  uint64_t low1 = umul128(m, mul[1], &high1); // 64
+  uint64_t high0;                             // 64
+  umul128(m, mul[0], &high0);                 // 0
   uint64_t sum = high0 + low1;
   if (sum < high0) high1++; // overflow into high1
   return shiftright128(sum, high1, j - 64);
 }
 
-static inline uint64_t mulPow5divPow2(uint64_t m, int32_t i, int32_t j) {
-  // m is maximum 55 bits
-  uint64_t high1;                                       // 128
-  uint64_t low1 = umul128(m, POW5_SPLIT[i][1], &high1); // 64
-  uint64_t high0;                                       // 64
-  umul128(m, POW5_SPLIT[i][0], &high0);                 // 0
-  uint64_t sum = high0 + low1;
-  if (sum < high0) high1++; // overflow into high1
-  return shiftright128(sum, high1, j - 64);
+static inline uint64_t mulShiftAll(
+    uint64_t m, uint64_t* mul, int32_t j, uint64_t* vp, uint64_t* vm, uint32_t mmShift) {
+  *vp = mulShift(m + 2, mul, j);
+  *vm = mulShift(m - 1 - mmShift, mul, j);
+  return mulShift(m, mul, j);
 }
 
 #endif // HAS_UINT128


### PR DESCRIPTION
This significantly improves the performance of the fallback case by computing the upper and lower bounds relative to the exact value, rather than doing additional multiplications. The fallback case requires quite a few multiplications (unlike the cases where we have 64x64 bit multiplications available), making this a significant win.