### PR TITLE
Reduce d2s/f2s divergence, and more MSVC improvements

### DIFF
--- a/ryu/benchmark/benchmark.cc
+++ b/ryu/benchmark/benchmark.cc
@@ -114,7 +114,7 @@ static int bench32(int samples, int iterations, bool verbose) {
     high_resolution_clock::time_point t1 = high_resolution_clock::now();
     for (int j = 0; j < iterations; j++) {
       f2s_buffered(f, bufferown);
-      throwaway += strlen(bufferown);
+      throwaway += (int) strlen(bufferown);
     }
     high_resolution_clock::time_point t2 = high_resolution_clock::now();
     double delta1 = duration_cast<nanoseconds>( t2 - t1 ).count() / (double) iterations;
@@ -123,7 +123,7 @@ static int bench32(int samples, int iterations, bool verbose) {
     t1 = high_resolution_clock::now();
     for (int j = 0; j < iterations; j++) {
       fcv(f);
-      throwaway += strlen(buffer);
+      throwaway += (int) strlen(buffer);
     }
     t2 = high_resolution_clock::now();
     double delta2 = duration_cast<nanoseconds>( t2 - t1 ).count() / (double) iterations;

--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -46,6 +46,8 @@ typedef __uint128_t uint128_t;
   && !defined(__clang__) // https://bugs.llvm.org/show_bug.cgi?id=37755
 
 #define HAS_64_BIT_INTRINSICS
+// MSVC calls it __inline, not inline in C mode.
+#define inline __inline
 
 #endif
 

--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -365,9 +365,9 @@ void d2s_buffered(double f, char* result) {
     printf("V+=%" PRIu64 "\nV =%" PRIu64 "\nV-=%" PRIu64 "\n", vp, vr, vm);
 #endif
     if (q <= 1) {
-      vrIsTrailingZeros = (~mv & 1) >= (uint64_t) q;
+      vrIsTrailingZeros = (~((uint32_t) mv) & 1) >= (uint32_t) q;
       if (acceptBounds) {
-        vmIsTrailingZeros = (~(mv - 1 - mmShift) & 1) >= (uint64_t) q;
+        vmIsTrailingZeros = (~((uint32_t) (mv - 1 - mmShift)) & 1) >= (uint32_t) q;
       } else {
         vp -= 1;
       }

--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -270,9 +270,9 @@ static inline uint32_t decimalLength(uint64_t v) {
 
 void d2s_buffered(double f, char* result) {
   // Step 1: Decode the floating point number, and unify normalized and subnormal cases.
-  int32_t mantissaBits = DOUBLE_MANTISSA_BITS;
-  int32_t exponentBits = DOUBLE_EXPONENT_BITS;
-  int32_t offset = (1 << (exponentBits - 1)) - 1;
+  uint32_t mantissaBits = DOUBLE_MANTISSA_BITS;
+  uint32_t exponentBits = DOUBLE_EXPONENT_BITS;
+  uint32_t offset = (1 << (exponentBits - 1)) - 1;
 
   uint64_t bits = 0;
   // This only works on little-endian architectures.
@@ -281,7 +281,7 @@ void d2s_buffered(double f, char* result) {
   // Decode bits into sign, mantissa, and exponent.
   bool sign = ((bits >> (mantissaBits + exponentBits)) & 1) != 0;
   uint64_t ieeeMantissa = bits & ((1ull << mantissaBits) - 1);
-  int32_t ieeeExponent = (int32_t) ((bits >> mantissaBits) & ((1 << exponentBits) - 1));
+  uint32_t ieeeExponent = (uint32_t) ((bits >> mantissaBits) & ((1 << exponentBits) - 1));
 
 #ifdef DEBUG_RYU
   printf("IN=");
@@ -294,7 +294,7 @@ void d2s_buffered(double f, char* result) {
   int32_t e2;
   uint64_t m2;
   // Case distinction; exit early for the easy cases.
-  if (ieeeExponent == ((1 << exponentBits) - 1)) {
+  if (ieeeExponent == ((1u << exponentBits) - 1u)) {
     strcpy(result, (ieeeMantissa != 0) ? "NaN" : sign ? "-Infinity" : "Infinity");
     return;
   } else if (ieeeExponent == 0) {
@@ -395,7 +395,7 @@ void d2s_buffered(double f, char* result) {
 #endif
 
   // Step 4: Find the shortest decimal representation in the interval of legal representations.
-  int32_t vplength = decimalLength(vp);
+  uint32_t vplength = decimalLength(vp);
   int32_t exp = e10 + vplength - 1;
 
   uint32_t removed = 0;

--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -299,7 +299,7 @@ void d2s_buffered(double f, char* result) {
     return;
   } else if (ieeeExponent == 0) {
     if (ieeeMantissa == 0) {
-      strcpy(result, sign ? "-0.0" : "0.0");
+      strcpy(result, sign ? "-0E0" : "0E0");
       return;
     }
     // We subtract 2 so that the bounds computation has 2 additional bits.

--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -46,8 +46,6 @@ typedef __uint128_t uint128_t;
   && !defined(__clang__) // https://bugs.llvm.org/show_bug.cgi?id=37755
 
 #define HAS_64_BIT_INTRINSICS
-// MSVC calls it __inline, not inline in C mode.
-#define inline __inline
 
 #endif
 
@@ -158,18 +156,16 @@ static inline uint64_t mulShiftAll(
 #elif defined(HAS_64_BIT_INTRINSICS)
 
 #include <intrin.h>
-#define umul128 _umul128
-#define shiftright128 __shiftright128
 
 static inline uint64_t mulShift(uint64_t m, const uint64_t* mul, int32_t j) {
   // m is maximum 55 bits
-  uint64_t high1;                             // 128
-  uint64_t low1 = umul128(m, mul[1], &high1); // 64
-  uint64_t high0;                             // 64
-  umul128(m, mul[0], &high0);                 // 0
+  uint64_t high1;                              // 128
+  uint64_t low1 = _umul128(m, mul[1], &high1); // 64
+  uint64_t high0;                              // 64
+  _umul128(m, mul[0], &high0);                 // 0
   uint64_t sum = high0 + low1;
   if (sum < high0) high1++; // overflow into high1
-  return shiftright128(sum, high1, (unsigned char) (j - 64));
+  return __shiftright128(sum, high1, (unsigned char) (j - 64));
 }
 
 static inline uint64_t mulShiftAll(

--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -15,6 +15,8 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied.
 
+// Compile with -DDEBUG_RYU to get very verbose debugging output to stdout.
+
 #include "ryu/ryu.h"
 
 #include <stdbool.h>
@@ -79,6 +81,7 @@ static inline uint32_t pow5Factor(uint32_t value) {
   return 0;
 }
 
+// Returns true if value divides 5^p.
 static inline bool multipleOfPowerOf5(uint32_t value, int32_t p) {
   return pow5Factor(value) >= (uint32_t) p;
 }
@@ -153,6 +156,7 @@ void f2s_buffered(float f, char* result) {
       strcpy(result, sign ? "-0E0" : "0E0");
       return;
     }
+    // We subtract 2 so that the bounds computation has 2 additional bits.
     e2 = 1 - offset - mantissaBits - 2;
     m2 = ieeeMantissa;
   } else {

--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -232,7 +232,7 @@ void f2s_buffered(float f, char* result) {
       if (acceptBounds) {
         vmIsTrailingZeros = (~mm & 1) >= (uint32_t) q;
       } else {
-        vp -= 1 >= q;
+        vp -= 1;
       }
     } else if (q < 31) { // TODO(ulfjack): Use a tighter bound here.
       vrIsTrailingZeros = (mv & ((1 << (q - 1)) - 1)) == 0;

--- a/ryu/tests/d2s_test.cc
+++ b/ryu/tests/d2s_test.cc
@@ -27,8 +27,8 @@ static double int64Bits2Double(uint64_t bits) {
 }
 
 TEST(D2sTest, Basic) {
-  ASSERT_STREQ("0.0", d2s(0.0));
-  ASSERT_STREQ("-0.0", d2s(-0.0));
+  ASSERT_STREQ("0E0", d2s(0.0));
+  ASSERT_STREQ("-0E0", d2s(-0.0));
   ASSERT_STREQ("1E0", d2s(1.0));
   ASSERT_STREQ("-1E0", d2s(-1.0));
   ASSERT_STREQ("NaN", d2s(NAN));


### PR DESCRIPTION
Diffing d2s.c against f2s.c with VSCode revealed several places where the code could be more consistent, including a behavioral change. (I'm now verifying these changes with d2s_test.cc, f2s_test.cc, and benchmark.cc.) There are a few remaining differences involving the signedness of constants that I might try to address in the future.

This also contains two commits with MSVC improvements - a simple warning fix in benchmark.cc, and intrinsic macro improvements. (I suspect that the `inline` macro was needed for earlier versions of MSVC, but it isn't needed by current versions, and removing it makes d2s.c consistent with f2s.c.)