### PR TITLE
Fix MSVC x64 truncation warning.

### DIFF
--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -147,7 +147,7 @@ static inline uint64_t mulShift(uint64_t m, const uint64_t* mul, int32_t j) {
   umul128(m, mul[0], &high0);                 // 0
   uint64_t sum = high0 + low1;
   if (sum < high0) high1++; // overflow into high1
-  return shiftright128(sum, high1, (unsigned char) (j - 64));
+  return shiftright128(sum, high1, j - 64);
 }
 
 static inline uint64_t mulShiftAll(

--- a/ryu/mulshift128.h
+++ b/ryu/mulshift128.h
@@ -28,7 +28,7 @@ static inline uint64_t umul128(uint64_t a, uint64_t b, uint64_t* productHi) {
 }
 
 static inline uint64_t shiftright128(uint64_t lo, uint64_t hi, uint64_t dist) {
-  return __shiftright128(lo, hi, dist);
+  return __shiftright128(lo, hi, (unsigned char) dist);
 }
 
 #else // defined(HAS_64_BIT_INTRINSICS)


### PR DESCRIPTION
warning C4244: conversion from 'uint64_t' to 'unsigned char', possible loss of data

This is emitted because the `__shiftright128` intrinsic is declared as taking `unsigned char`, and reappeared due to recent refactoring. Now, mulshift128.h is a centralized location where we can silence this warning.

(This also adds a newline to the end of mulshift128.h. My editor is configured to automatically do this, and some compilers warn when they see headers that don't end with newlines.)