### PR TITLE
Make 64-bit printing on 32-bit platforms 9% to 12% faster.

### DIFF
--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -449,7 +449,7 @@ void d2s_buffered(double f, char* result) {
     memcpy(result + index + olength - i - 3, DIGIT_TABLE + c1, 2);
     i += 4;
   }
-  while (output >= 100) {
+  if (output >= 100) {
     uint32_t c = (uint32_t) ((output - 100 * (output / 100)) << 1); // (output % 100) << 1;
     output /= 100;
     memcpy(result + index + olength - i - 1, DIGIT_TABLE + c, 2);

--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -440,28 +440,57 @@ void d2s_buffered(double f, char* result) {
 #ifndef NO_DIGIT_TABLE
   // Print decimal digits after the decimal point.
   uint32_t i = 0;
-  while (output >= 10000) {
-    uint32_t c = (uint32_t) (output - 10000 * (output / 10000)); // output % 10000;
-    output /= 10000;
+#if defined(_M_IX86) || defined(_M_ARM)
+  // 64-bit division is inefficient on 32-bit platforms.
+  uint32_t output2;
+  while ((output >> 32) != 0) {
+    // Expensive 64-bit division.
+    output2 = (uint32_t) (output - 1000000000 * (output / 1000000000)); // output % 1000000000
+    output /= 1000000000;
+
+    // Cheap 32-bit divisions.
+    uint32_t c = output2 - 10000 * (output2 / 10000); // output2 % 10000;
+    output2 /= 10000;
+    uint32_t d = output2 - 10000 * (output2 / 10000); // output2 % 10000;
+    output2 /= 10000;
+    uint32_t c0 = (c % 100) << 1;
+    uint32_t c1 = (c / 100) << 1;
+    uint32_t d0 = (d % 100) << 1;
+    uint32_t d1 = (d / 100) << 1;
+    memcpy(result + index + olength - i - 1, DIGIT_TABLE + c0, 2);
+    memcpy(result + index + olength - i - 3, DIGIT_TABLE + c1, 2);
+    memcpy(result + index + olength - i - 5, DIGIT_TABLE + d0, 2);
+    memcpy(result + index + olength - i - 7, DIGIT_TABLE + d1, 2);
+    result[index + olength - i - 8] = (char) ('0' + output2);
+    i += 9;
+  }
+  output2 = (uint32_t) output;
+#else // ^^^ known 32-bit platforms ^^^ / vvv other platforms vvv
+  // 64-bit division is efficient on 64-bit platforms.
+  uint64_t output2 = output;
+#endif // ^^^ other platforms ^^^
+  while (output2 >= 10000) {
+    uint32_t c = (uint32_t) (output2 - 10000 * (output2 / 10000)); // output2 % 10000;
+    output2 /= 10000;
     uint32_t c0 = (c % 100) << 1;
     uint32_t c1 = (c / 100) << 1;
     memcpy(result + index + olength - i - 1, DIGIT_TABLE + c0, 2);
     memcpy(result + index + olength - i - 3, DIGIT_TABLE + c1, 2);
     i += 4;
   }
-  if (output >= 100) {
-    uint32_t c = (uint32_t) ((output - 100 * (output / 100)) << 1); // (output % 100) << 1;
-    output /= 100;
+  if (output2 >= 100) {
+    uint32_t c = (uint32_t) ((output2 - 100 * (output2 / 100)) << 1); // (output2 % 100) << 1;
+    output2 /= 100;
     memcpy(result + index + olength - i - 1, DIGIT_TABLE + c, 2);
     i += 2;
   }
-  if (output >= 10) {
-    uint32_t c = (uint32_t) (output << 1);
+  if (output2 >= 10) {
+    uint32_t c = (uint32_t) (output2 << 1);
     result[index + olength - i] = DIGIT_TABLE[c + 1];
     result[index] = DIGIT_TABLE[c];
   } else {
     // Print the leading decimal digit.
-    result[index] = (char) ('0' + output);
+    result[index] = (char) ('0' + output2);
   }
 #else
   // Print decimal digits after the decimal point.

--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -318,7 +318,7 @@ void f2s_buffered(float f, char* result) {
     memcpy(result + index + olength - i - 3, DIGIT_TABLE + c1, 2);
     i += 4;
   }
-  while (output >= 100) {
+  if (output >= 100) {
     uint32_t c = (output - 100 * (output / 100)) << 1; // (output % 100) << 1;
     output /= 100;
     memcpy(result + index + olength - i - 1, DIGIT_TABLE + c, 2);


### PR DESCRIPTION
Printing 64-bit doubles on 32-bit platforms is the slowest scenario, but there's a simple way to improve this. Because the core Ryu algorithm is so fast, a relatively large amount of time is spent on the mundane task of decomposing an integer into decimal digits. This involves expensive 64-bit divisions, partially mitigated by the digit table. It's possible to do most of the work with cheap 32-bit divisions. The strategy is:

* When we detect a 32-bit platform, activate the new code. (I'm currently checking MSVC's platform macros, which I'm familiar with. Other platform macros can be added in the future. Note that I've phrased this preprocessor check so that unknown platforms use the original code. Alternatively, the preprocessor could be avoided by testing `sizeof(void *)` and using `size_t` for the type of `output2`, although a "conditional expression is constant" warning would need to be silenced.)

* Loop while `output` doesn't fit within `uint32_t`. (Tested by examining the high 32 bits, in an attempt to be compiler-friendly.)

* Perform an expensive 64-bit division by 10^9. (This loop will run at most twice, for 19-digit and 20-digit numbers.)

* Use 32-bit divisions to print 9 digits at a time. Note that this prints leading zeroes because we know we have more work to do. (This loop runs when `output` is at least 2^32, so `output` has at least 10 digits.)

* When `output` fits within `uint32_t`, we exit the loop, assign it to `output2`, and perform the rest of the work with that 32-bit value.

* For other platforms, we define `output2` to be `uint64_t`, allowing the following code to be shared.

I observe that this improves performance for both MSVC and Clang 6.0.0. Tested with /MT /O2 but without link-time codegen:

MSVC before: 202.369 ns
MSVC after: 185.923 ns
Clang before: 149.431 ns
Clang after: 133.485 ns

This also contains a minor improvement to remove unnecessary loops. After `while (output >= 10000)` terminates, output is at most 9999. The `(output >= 100)` loop contains `output /= 100;`, so after one iteration, output is at most 99, so there can't be a second iteration. Therefore, this can just be an if-statement, slightly improving codegen.