### PR TITLE
Update LLVM bug numbers.

### DIFF
--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -476,7 +476,7 @@ void d2s_buffered(double f, char* result) {
   uint64_t output2 = output;
 #endif // ^^^ other platforms ^^^
   while (output2 >= 10000) {
-#ifdef __clang__ // https://bugs.llvm.org/show_bug.cgi?id=23106
+#ifdef __clang__ // https://bugs.llvm.org/show_bug.cgi?id=38217
     const uint32_t c = (uint32_t) (output2 - 10000 * (output2 / 10000));
 #else
     const uint32_t c = (uint32_t) (output2 % 10000);

--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -309,7 +309,7 @@ void f2s_buffered(float f, char* result) {
   // Print decimal digits after the decimal point.
   uint32_t i = 0;
   while (output >= 10000) {
-#ifdef __clang__ // https://bugs.llvm.org/show_bug.cgi?id=23106
+#ifdef __clang__ // https://bugs.llvm.org/show_bug.cgi?id=38217
     const uint32_t c = output - 10000 * (output / 10000);
 #else
     const uint32_t c = output % 10000;


### PR DESCRIPTION
Previously, I determined that only 3 modulo workarounds were necessary,
and commented all of them with LLVM#23106 "Division followed by modulo
generates longer machine code than vice versa". At the time, I noted
that only 1 of the 3 actually followed that pattern.

This mystery bothered me, so I reduced and filed LLVM#38217 "Clang/LLVM
optimizes division and modulo worse than MSVC, part 2" for the
mod-then-div pattern. (Div-then-mod and mod-then-div might be different
manifestations of the same underlying bug, but now LLVM's devs can
determine whether that's true.)

This change simply updates the workaround comments accordingly.