### PR TITLE
Comment fixes and cleanups.

### DIFF
--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -68,13 +68,13 @@ static inline int32_t pow5Factor(uint64_t value) {
   return 0;
 }
 
-// Returns true if value divides 5^p.
+// Returns true if value is divisible by 5^p.
 static inline bool multipleOfPowerOf5(const uint64_t value, const int32_t p) {
   // I tried a case distinction on p, but there was no performance difference.
   return pow5Factor(value) >= p;
 }
 
-// We need a 64x128 bit multiplication and a subsequent 128-bit shift.
+// We need a 64x128-bit multiplication and a subsequent 128-bit shift.
 // Multiplication:
 //   The 64-bit factor is variable and passed in, the 128-bit factor comes
 //   from a lookup table. We know that the 64-bit factor only has 55
@@ -89,7 +89,7 @@ static inline bool multipleOfPowerOf5(const uint64_t value, const int32_t p) {
 //   the 64x128-bit multiplication.
 //
 // There are several ways to do this:
-// 1. Best case: the compiler exposes a 128-bit type
+// 1. Best case: the compiler exposes a 128-bit type.
 //    We perform two 64x64-bit multiplications, add the higher 64 bits of the
 //    lower result to the higher result, and shift by j-64 bits.
 //
@@ -105,7 +105,7 @@ static inline bool multipleOfPowerOf5(const uint64_t value, const int32_t p) {
 // 3. We only have 64x64 bit instructions that return the lower 64 bits of
 //    the result, i.e., we have to use plain C.
 //    Our inputs are less than the full width, so we have three options:
-//    a. Ignore this fact and just implement the intrinsics manually
+//    a. Ignore this fact and just implement the intrinsics manually.
 //    b. Split both into 31-bit pieces, which guarantees no internal overflow,
 //       but requires extra work upfront (unless we change the lookup table).
 //    c. Split only the first factor into 31-bit pieces, which also guarantees

--- a/ryu/digit_table.h
+++ b/ryu/digit_table.h
@@ -17,7 +17,7 @@
 #ifndef RYU_DIGIT_TABLE_H
 #define RYU_DIGIT_TABLE_H
 
-// A table of all two digit numbers. This is used to speed up decimal digit
+// A table of all two-digit numbers. This is used to speed up decimal digit
 // generation by copying pairs of digits into the final output.
 static const char DIGIT_TABLE[200] = {
   '0','0','0','1','0','2','0','3','0','4','0','5','0','6','0','7','0','8','0','9',

--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -83,7 +83,7 @@ static inline int32_t pow5Factor(uint32_t value) {
   return 0;
 }
 
-// Returns true if value divides 5^p.
+// Returns true if value is divisible by 5^p.
 static inline bool multipleOfPowerOf5(const uint32_t value, const int32_t p) {
   return pow5Factor(value) >= p;
 }


### PR DESCRIPTION
The comment for multipleOfPowerOf5() said "divides",
but it meant the reverse, "is divisible by".

Add periods to sentences for consistency with nearby list items.

Hyphenate "64x128-bit" and "two-digit" for consistency.