### PR TITLE
Call decimalLength() with output instead of vp.

### DIFF
--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -201,10 +201,8 @@ static inline uint64_t mulShiftAll(
 static inline uint32_t decimalLength(const uint64_t v) {
   // This is slightly faster than a loop. For a random set of numbers, the
   // average length is 17.4 digits, so we check high-to-low.
-  // 2^63 - 1 is 19 decimal digits, while 2^64 - 1 is 20 decimal digits.
-  // Function precondition: v is not a 20-digit number.
-  if (v >= 1000000000000000000L) { return 19; }
-  if (v >= 100000000000000000L) { return 18; }
+  // Function precondition: v is not an 18, 19, or 20-digit number.
+  // (17 digits are sufficient for round-tripping.)
   if (v >= 10000000000000000L) { return 17; }
   if (v >= 1000000000000000L) { return 16; }
   if (v >= 100000000000000L) { return 15; }
@@ -363,9 +361,6 @@ void d2s_buffered(double f, char* result) {
 #endif
 
   // Step 4: Find the shortest decimal representation in the interval of legal representations.
-  const uint32_t vplength = decimalLength(vp);
-  int32_t exp = e10 + vplength - 1;
-
   uint32_t removed = 0;
   uint8_t lastRemovedDigit = 0;
   uint64_t output;
@@ -429,7 +424,10 @@ void d2s_buffered(double f, char* result) {
     output = vr + ((vr == vm) || (lastRemovedDigit >= 5));
   }
   // The average output length is 16.38 digits.
-  const uint32_t olength = vplength - removed;
+  const uint32_t olength = decimalLength(output);
+  const uint32_t vplength = olength + removed;
+  int32_t exp = e10 + vplength - 1;
+
 #ifdef RYU_DEBUG
   printf("V+=%" PRIu64 "\nV =%" PRIu64 "\nV-=%" PRIu64 "\n", vp, vr, vm);
   printf("O=%" PRIu64 "\n", output);

--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -112,7 +112,8 @@ static inline uint64_t mulPow5divPow2(const uint32_t m, const uint32_t i, const 
 }
 
 static inline uint32_t decimalLength(const uint32_t v) {
-  if (v >= 1000000000) { return 10; }
+  // Function precondition: v is not a 10-digit number.
+  // (9 digits are sufficient for round-tripping.)
   if (v >= 100000000) { return 9; }
   if (v >= 10000000) { return 8; }
   if (v >= 1000000) { return 7; }
@@ -252,9 +253,6 @@ void f2s_buffered(float f, char* result) {
 #endif
 
   // Step 4: Find the shortest decimal representation in the interval of legal representations.
-  const uint32_t vplength = decimalLength(vp);
-  int32_t exp = e10 + vplength - 1;
-
   uint32_t removed = 0;
   uint32_t output;
   if (vmIsTrailingZeros || vrIsTrailingZeros) {
@@ -297,7 +295,9 @@ void f2s_buffered(float f, char* result) {
     // We need to take vr+1 if vr is outside bounds or we need to round up.
     output = vr + ((vr == vm) || (lastRemovedDigit >= 5));
   }
-  const uint32_t olength = vplength - removed;
+  const uint32_t olength = decimalLength(output);
+  const uint32_t vplength = olength + removed;
+  int32_t exp = e10 + vplength - 1;
 
   // Step 5: Print the decimal representation.
   int index = 0;


### PR DESCRIPTION
NOTE: My understanding of the algorithm is incomplete, so I'm not
certain that this change is correct. I ran
`benchmark -samples=100000000 -iterations=1` with x86/x64 Clang/MSVC
and it always succeeded.

According to my understanding, vp contains the decimal digits before
trimming, while output contains the decimal digits after trimming.
vplength and olength contain how many decimal digits are in each
variable, with `removed` being the difference. (I'm more certain about
output and olength's behavior, since I can see how they're used in the
final digit-printing step, with olength being used to write the least
significant digits at the highest memory addresses first.)

I noticed that vplength is calculated early, but is almost unused until
`removed` is finished and used to calculate olength. Until then, the
only thing that vplength is used for is exp, which isn't used until far
later. (e10 is used to calculate exp, but it undergoes no further
changes at this point.)

So I believe that we can perform a simple transformation:

* Wait until trimming is done, then olength is decimalLength(output).
* Now vplength is olength + removed.
* Calculate exp as before.

The advantage of this is that decimalLength() can now assume that it's
being called with trimmed output, so it can perform less work. (This
also resolves a mystery for me, or at least makes it moot;
decimalLength(uint64_t) couldn't handle 20-digit numbers, which was
fine because vplength is somehow never that big. Now
decimalLength(uint64_t) doesn't need to handle 18-digit numbers for a
reason that I clearly understand.)

Due to how this simply moves around code and drops a few branches (at
the beginning, where it's important to do as little work as possible),
I expect this to be a strict, minor improvement. Benchmarking (with
default options) appears to confirm this, although there's a little bit
of noise AFAICT:

----

x86 Clang before, best of 5
32:   33.399    4.916      193.893  109.941
64:  127.874   12.462      246.733  201.639

x86 Clang after, best of 5
32:   32.601    5.127      197.664  109.057
64:  124.791   12.353      247.367  203.965

----

x64 Clang before, best of 5
32:   21.168    1.515      140.709  107.833
64:   29.875    1.835      157.111  167.956

x64 Clang after, best of 5
32:   21.430    1.535      143.143  108.123
64:   29.401    1.782      158.800  165.335

----

x86 MSVC before, best of 5
32:   39.046    5.500      272.214  116.121
64:  144.434   13.294      351.746  220.858

x86 MSVC after, best of 5
32:   38.711    5.111      273.558  116.326
64:  146.238   13.490      350.479  206.936

----

x64 MSVC before, best of 5
32:   24.110    1.850      176.120  122.888
64:   28.546    1.868      203.900  204.986

x64 MSVC after, best of 5
32:   23.429    1.862      177.301  126.726
64:   28.387    1.732      200.885  198.263

----

(The MSVC numbers were obtained with an unrelated __forceinline
workaround for a compiler bug that I've internally reported.)