### PR TITLE
Small improvements for d2s (on x86 platforms)

### DIFF
--- a/ryu/mulshift128.h
+++ b/ryu/mulshift128.h
@@ -44,15 +44,16 @@ static inline uint64_t shiftright128(const uint64_t lo, const uint64_t hi, const
 #else // defined(HAS_64_BIT_INTRINSICS)
 
 static inline uint64_t umul128(const uint64_t a, const uint64_t b, uint64_t* const productHi) {
-  const uint64_t aLo = a & 0xffffffffu;
-  const uint64_t aHi = a >> 32;
-  const uint64_t bLo = b & 0xffffffffu;
-  const uint64_t bHi = b >> 32;
+  // The casts here help MSVC to avoid calls to the __allmul library function.
+  const uint32_t aLo = (uint32_t)a;
+  const uint32_t aHi = (uint32_t)(a >> 32);
+  const uint32_t bLo = (uint32_t)b;
+  const uint32_t bHi = (uint32_t)(b >> 32);
 
-  const uint64_t b00 = aLo * bLo;
-  const uint64_t b01 = aLo * bHi;
-  const uint64_t b10 = aHi * bLo;
-  const uint64_t b11 = aHi * bHi;
+  const uint64_t b00 = (uint64_t)aLo * bLo;
+  const uint64_t b01 = (uint64_t)aLo * bHi;
+  const uint64_t b10 = (uint64_t)aHi * bLo;
+  const uint64_t b11 = (uint64_t)aHi * bHi;
 
   const uint64_t midSum = b01 + b10;
   const uint64_t midCarry = midSum < b01;


### PR DESCRIPTION
Two minor changes which should improve the performance for `d2s` on x86 platforms

1. The shift count in `shiftright128` is always less than 64 in the current implementation. This allows to remove a branch in this function.

2. Added some 32/64-bit casts to `umul128`. This allows MSVC to avoid calls to the `__allmul` library function. This shouldn't affect codegen for other compilers (but I haven't checked).

I have tested the code using MSVC x86 (on Windows 10 x64, though) and the performance improvement was about 10%.  I haven't benchmarked (and tested) the code on genuine 32-bit platforms, though.