### PR TITLE
Small improvements for f2s (on x86 platforms)

### DIFF
--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -109,8 +109,12 @@ static inline int32_t log10Pow5(const int32_t e) {
 // generated code for uint128_t looks slightly nicer.
 static inline uint32_t mulPow5InvDivPow2(const uint32_t m, const uint32_t q, const int32_t j) {
   const uint64_t factor = FLOAT_POW5_INV_SPLIT[q];
-  const uint64_t bits0 = m * (factor & 0xffffffffu);
-  const uint64_t bits1 = m * (factor >> 32);
+  // The casts here help MSVC to avoid calls to the __allmul library
+  // function.
+  const uint32_t factorLo = (uint32_t)(factor);
+  const uint32_t factorHi = (uint32_t)(factor >> 32);
+  const uint64_t bits0 = (uint64_t)m * factorLo;
+  const uint64_t bits1 = (uint64_t)m * factorHi;
   const uint64_t sum = (bits0 >> 32) + bits1;
   assert(j >= 32);
   const uint64_t shiftedSum = sum >> (j - 32);
@@ -120,8 +124,12 @@ static inline uint32_t mulPow5InvDivPow2(const uint32_t m, const uint32_t q, con
 
 static inline uint32_t mulPow5divPow2(const uint32_t m, const uint32_t i, const int32_t j) {
   const uint64_t factor = FLOAT_POW5_SPLIT[i];
-  const uint64_t bits0 = m * (factor & 0xffffffffu);
-  const uint64_t bits1 = m * (factor >> 32);
+  // The casts here help MSVC to avoid calls to the __allmul library
+  // function.
+  const uint32_t factorLo = (uint32_t)(factor);
+  const uint32_t factorHi = (uint32_t)(factor >> 32);
+  const uint64_t bits0 = (uint64_t)m * factorLo;
+  const uint64_t bits1 = (uint64_t)m * factorHi;
   const uint64_t sum = (bits0 >> 32) + bits1;
   assert(j >= 32);
   const uint64_t shiftedSum = sum >> (j - 32);

--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -117,10 +117,22 @@ static inline uint32_t mulShift(const uint32_t m, const uint64_t factor, const i
   const uint64_t bits0 = (uint64_t)m * factorLo;
   const uint64_t bits1 = (uint64_t)m * factorHi;
 
+#if defined(_M_IX86) || defined(_M_ARM)
+  // On 32-bit platforms we can avoid a 64-bit shift-right since we only
+  // need the upper 32-bits of the result and the shift value is >= 32.
+  const uint32_t bits0Hi = (uint32_t)(bits0 >> 32);
+  uint32_t bits1Lo = (uint32_t)(bits1);
+  uint32_t bits1Hi = (uint32_t)(bits1 >> 32);
+  bits1Lo += bits0Hi;
+  bits1Hi += (bits1Lo < bits0Hi);
+  const int32_t s = shift - 32;
+  return (bits1Hi << (32 - s)) | (bits1Lo >> s);
+#else
   const uint64_t sum = (bits0 >> 32) + bits1;
   const uint64_t shiftedSum = sum >> (shift - 32);
   assert(shiftedSum <= UINT32_MAX);
   return (uint32_t) shiftedSum;
+#endif
 }
 
 static inline uint32_t mulPow5InvDivPow2(const uint32_t m, const uint32_t q, const int32_t j) {

--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -107,34 +107,28 @@ static inline int32_t log10Pow5(const int32_t e) {
 
 // It seems to be slightly faster to avoid uint128_t here, although the
 // generated code for uint128_t looks slightly nicer.
-static inline uint32_t mulPow5InvDivPow2(const uint32_t m, const uint32_t q, const int32_t j) {
-  const uint64_t factor = FLOAT_POW5_INV_SPLIT[q];
+static inline uint32_t mulShift(const uint32_t m, const uint64_t factor, const int32_t shift) {
+  assert(shift >= 32);
+
   // The casts here help MSVC to avoid calls to the __allmul library
   // function.
   const uint32_t factorLo = (uint32_t)(factor);
   const uint32_t factorHi = (uint32_t)(factor >> 32);
   const uint64_t bits0 = (uint64_t)m * factorLo;
   const uint64_t bits1 = (uint64_t)m * factorHi;
+
   const uint64_t sum = (bits0 >> 32) + bits1;
-  assert(j >= 32);
-  const uint64_t shiftedSum = sum >> (j - 32);
+  const uint64_t shiftedSum = sum >> (shift - 32);
   assert(shiftedSum <= UINT32_MAX);
   return (uint32_t) shiftedSum;
 }
 
+static inline uint32_t mulPow5InvDivPow2(const uint32_t m, const uint32_t q, const int32_t j) {
+  return mulShift(m, FLOAT_POW5_INV_SPLIT[q], j);
+}
+
 static inline uint32_t mulPow5divPow2(const uint32_t m, const uint32_t i, const int32_t j) {
-  const uint64_t factor = FLOAT_POW5_SPLIT[i];
-  // The casts here help MSVC to avoid calls to the __allmul library
-  // function.
-  const uint32_t factorLo = (uint32_t)(factor);
-  const uint32_t factorHi = (uint32_t)(factor >> 32);
-  const uint64_t bits0 = (uint64_t)m * factorLo;
-  const uint64_t bits1 = (uint64_t)m * factorHi;
-  const uint64_t sum = (bits0 >> 32) + bits1;
-  assert(j >= 32);
-  const uint64_t shiftedSum = sum >> (j - 32);
-  assert(shiftedSum <= UINT32_MAX);
-  return (uint32_t) shiftedSum;
+  return mulShift(m, FLOAT_POW5_SPLIT[i], j);
 }
 
 static inline uint32_t decimalLength(const uint32_t v) {


### PR DESCRIPTION
Some changes to improve the performance for d2s on x86 platforms.

Basically this adds a `mulShift` function like the one in the `d2s` implementation. 
For 32-bit platforms this function avoids 64-bit arithmetic. This greatly helps MSVC x86 to generate faster code.

The behavior (and performance) is unaffected for 64-bit.

On my test PC (64-bit) the performance improvements with MSVC x86 were ~20%. I haven't tested or benchmarked the code on a genuine 32-bit platform, though.