### PR TITLE
Add common.h, improve assertions and comments.

### DIFF
--- a/ryu/BUILD
+++ b/ryu/BUILD
@@ -9,6 +9,7 @@ cc_library(
     "d2s_full_table.h",
     "digit_table.h",
     "mulshift128.h",
+    "common.h",
   ],
   hdrs = ["ryu.h"],
 )

--- a/ryu/common.h
+++ b/ryu/common.h
@@ -1,0 +1,47 @@
+// Copyright 2018 Ulf Adams
+//
+// The contents of this file may be used under the terms of the Apache License,
+// Version 2.0.
+//
+//    (See accompanying file LICENSE-Apache or copy at
+//     http://www.apache.org/licenses/LICENSE-2.0)
+//
+// Alternatively, the contents of this file may be used under the terms of
+// the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE-Boost or copy at
+//     https://www.boost.org/LICENSE_1_0.txt)
+//
+// Unless required by applicable law or agreed to in writing, this software
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+#ifndef RYU_COMMON_H
+#define RYU_COMMON_H
+
+#include <assert.h>
+#include <stdint.h>
+
+// Returns e == 0 ? 1 : ceil(log_2(5^e)).
+static inline uint32_t pow5bits(const int32_t e) {
+  // This function has only been tested for 0 <= e <= 1500.
+  assert(e >= 0);
+  assert(e <= 1500);
+  return ((((uint32_t) e) * 1217359) >> 19) + 1;
+}
+
+// Returns floor(log_10(2^e)).
+static inline int32_t log10Pow2(const int32_t e) {
+  // This function has only been tested for 0 <= e <= 1500.
+  assert(e >= 0);
+  assert(e <= 1500);
+  return (int32_t) ((((uint32_t) e) * 78913) >> 18);
+}
+
+// Returns floor(log_10(5^e)).
+static inline int32_t log10Pow5(const int32_t e) {
+  // This function has only been tested for 0 <= e <= 1500.
+  assert(e >= 0);
+  assert(e <= 1500);
+  return (int32_t) ((((uint32_t) e) * 732923) >> 20);
+}
+
+#endif // RYU_COMMON_H

--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -29,6 +29,7 @@
 
 #include "ryu/ryu.h"
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -211,10 +212,11 @@ static inline uint64_t mulShiftAll(
 #endif // HAS_64_BIT_INTRINSICS
 
 static inline uint32_t decimalLength(const uint64_t v) {
-  // This is slightly faster than a loop. For a random set of numbers, the
-  // average length is 17.4 digits, so we check high-to-low.
+  // This is slightly faster than a loop.
+  // The average output length is 16.38 digits, so we check high-to-low.
   // Function precondition: v is not an 18, 19, or 20-digit number.
   // (17 digits are sufficient for round-tripping.)
+  assert(v < 100000000000000000L);
   if (v >= 10000000000000000L) { return 17; }
   if (v >= 1000000000000000L) { return 16; }
   if (v >= 100000000000000L) { return 15; }
@@ -330,7 +332,7 @@ void d2s_buffered(double f, char* result) {
       }
     }
   } else {
-    // This expression is slightly faster than max(0, log10Pow5(-e2) - 1)
+    // This expression is slightly faster than max(0, log10Pow5(-e2) - 1).
     const int32_t q = log10Pow5(-e2) - (-e2 > 1);
     e10 = q + e2;
     const int32_t i = -e2 - q;
@@ -359,7 +361,7 @@ void d2s_buffered(double f, char* result) {
       // We need to compute min(ntz(mv), pow5Factor(mv) - e2) >= q-1
       // <=> ntz(mv) >= q-1  &&  pow5Factor(mv) - e2 >= q-1
       // <=> ntz(mv) >= q-1
-      // <=> mv & ((1 << (q-1)) - 1) == 0
+      // <=> (mv & ((1 << (q-1)) - 1)) == 0
       // We also need to make sure that the left shift does not overflow.
       vrIsTrailingZeros = (mv & ((1ull << (q - 1)) - 1)) == 0;
 #ifdef RYU_DEBUG

--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -53,23 +53,8 @@
 #define HAS_64_BIT_INTRINSICS
 #endif
 
+#include "ryu/common.h"
 #include "ryu/d2s.h"
-
-// Returns floor(log_10(2^e)).
-static inline int32_t log10Pow2(const int32_t e) {
-  // This function has only been tested for 0 <= e <= 1500.
-  assert(e >= 0);
-  assert(e <= 1500);
-  return (int32_t) ((((uint32_t) e) * 78913) >> 18);
-}
-
-// Returns floor(log_10(5^e)).
-static inline int32_t log10Pow5(const int32_t e) {
-  // This function has only been tested for 0 <= e <= 1500.
-  assert(e >= 0);
-  assert(e <= 1500);
-  return (int32_t) ((((uint32_t) e) * 732923) >> 20);
-}
 
 static inline int32_t pow5Factor(uint64_t value) {
   for (int32_t count = 0; value > 0; ++count) {
@@ -302,7 +287,7 @@ void d2s_buffered(double f, char* result) {
     // This expression is slightly faster than max(0, log10Pow2(e2) - 1).
     const int32_t q = log10Pow2(e2) - (e2 > 3);
     e10 = q;
-    const int32_t k = DOUBLE_POW5_INV_BITCOUNT + double_pow5bits(q) - 1;
+    const int32_t k = DOUBLE_POW5_INV_BITCOUNT + pow5bits(q) - 1;
     const int32_t i = -e2 + q + k;
 #if defined(RYU_OPTIMIZE_SIZE)
     uint64_t pow5[2];
@@ -336,7 +321,7 @@ void d2s_buffered(double f, char* result) {
     const int32_t q = log10Pow5(-e2) - (-e2 > 1);
     e10 = q + e2;
     const int32_t i = -e2 - q;
-    const int32_t k = double_pow5bits(i) - DOUBLE_POW5_BITCOUNT;
+    const int32_t k = pow5bits(i) - DOUBLE_POW5_BITCOUNT;
     const int32_t j = q - k;
 #if defined(RYU_OPTIMIZE_SIZE)
     uint64_t pow5[2];

--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -108,7 +108,7 @@ static inline int32_t log10Pow5(const int32_t e) {
 // It seems to be slightly faster to avoid uint128_t here, although the
 // generated code for uint128_t looks slightly nicer.
 static inline uint32_t mulShift(const uint32_t m, const uint64_t factor, const int32_t shift) {
-  assert(shift >= 32);
+  assert(shift > 32);
 
   // The casts here help MSVC to avoid calls to the __allmul library
   // function.
@@ -119,7 +119,7 @@ static inline uint32_t mulShift(const uint32_t m, const uint64_t factor, const i
 
 #if defined(_M_IX86) || defined(_M_ARM)
   // On 32-bit platforms we can avoid a 64-bit shift-right since we only
-  // need the upper 32-bits of the result and the shift value is >= 32.
+  // need the upper 32 bits of the result and the shift value is > 32.
   const uint32_t bits0Hi = (uint32_t)(bits0 >> 32);
   uint32_t bits1Lo = (uint32_t)(bits1);
   uint32_t bits1Hi = (uint32_t)(bits1 >> 32);
@@ -146,6 +146,7 @@ static inline uint32_t mulPow5divPow2(const uint32_t m, const uint32_t i, const 
 static inline uint32_t decimalLength(const uint32_t v) {
   // Function precondition: v is not a 10-digit number.
   // (9 digits are sufficient for round-tripping.)
+  assert(v < 1000000000);
   if (v >= 100000000) { return 9; }
   if (v >= 10000000) { return 8; }
   if (v >= 1000000) { return 7; }

--- a/ryu/mulshift128.h
+++ b/ryu/mulshift128.h
@@ -66,7 +66,8 @@ static inline uint64_t umul128(const uint64_t a, const uint64_t b, uint64_t* con
 }
 
 static inline uint64_t shiftright128(const uint64_t lo, const uint64_t hi, const uint32_t dist) {
-  // We don't need to handle the case dist > 64 here (see above).
+  // We don't need to handle the case dist >= 64 here (see above).
+  assert(dist > 0);
   assert(dist < 64);
   return (hi << (64 - dist)) | (lo >> dist);
 }


### PR DESCRIPTION
Add common.h to avoid code duplication. The implementations of
these functions were exactly identical.

Improve assertions and comments.

d2s.c:
* Update decimalLength()'s comment, as it's now called with trimmed
output.
* Add an assertion for decimalLength()'s precondition. Include assert.h
for this.
* Add a period to the "slightly faster" comment for consistency.
* Add parentheses to a comment for consistency with the actual code
(required by C's precedence rules).

f2s.c:
* In mulShift(), change assert(shift >= 32) to assert(shift > 32),
because shift == 32 would lead to a forbidden "full shift" below
(undefined behavior in C, with varying behavior between x86 and ARM).
Update the comment accordingly. This passed
`benchmark -samples=1000000000 -iterations=1` with assertions enabled.
* Remove the hyphen from "the upper 32-bits", as this is a noun.
* Assert decimalLength()'s precondition.

mulshift128.h:
* Comment fix: the negation of dist < 64 is dist >= 64.
* Assert dist > 0 (valid due to the detailed analysis in the comment
above) as this would lead to a forbidden full shift. We could similarly
assert in the intrinsic version, but I didn't think that was necessary.