### PR TITLE
C benchmark compilation requires "-l m"

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The resulting files are `bazel-genfiles/scripts/{c,java}-{float,double}.pdf`.
 You can build and run the C benchmark without using Bazel with the following shell
 command:
 ```
-$ gcc -o benchmark -I. -O2 -l stdc++ ryu/*.c ryu/benchmark/benchmark.cc \
+$ gcc -o benchmark -I. -O2 -l m -l stdc++ ryu/*.c ryu/benchmark/benchmark.cc \
     third_party/double-conversion/double-conversion/*.cc \
     third_party/mersenne/*.c
 $ ./benchmark


### PR DESCRIPTION
without "-l m" (linking to the maths library) I get "undefined reference to symbol 'sqrt@@GLIBC_2.2.5'" on Debian Stretch with gcc 6.3.0