### PR TITLE
Fix RYU_DEBUG and MSVC warnings, add const, cleanup comments.

### DIFF
--- a/ryu/common.h
+++ b/ryu/common.h
@@ -46,7 +46,7 @@ static inline int32_t log10Pow5(const int32_t e) {
   return (int32_t) ((((uint32_t) e) * 732923) >> 20);
 }
 
-static inline int copy_special_str(char * result, bool sign, bool exponent, bool mantissa) {
+static inline int copy_special_str(char * const result, const bool sign, const bool exponent, const bool mantissa) {
   if (mantissa) {
     memcpy(result, "NaN", 3);
     return 3;

--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -545,10 +545,9 @@ int d2s_buffered_n(double f, char* result) {
 #endif
 
   // Step 5: Print the decimal representation.
-  struct floating_decimal_64 fd = {
-    .exponent = exp,
-    .mantissa = sign ? -(int64_t) output : output
-  };
+  struct floating_decimal_64 fd;
+  fd.exponent = (int16_t) exp;
+  fd.mantissa = sign ? -(int64_t) output : output;
   return fd_to_char(fd, result);
 }
 

--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -237,7 +237,7 @@ static inline int fd_to_char(const struct floating_decimal_64 v, char* const res
   const uint32_t olength = decimalLength(output);
 
 #ifdef RYU_DEBUG
-  printf("DIGITS=%" PRIu64 "\n", v.value);
+  printf("DIGITS=%" PRIu64 "\n", output);
   printf("OLEN=%d\n", olength);
   printf("EXP=%d\n", v.exponent + olength);
 #endif

--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -224,7 +224,7 @@ struct floating_decimal_64 {
   int64_t mantissa;
 };
 
-static inline int fd_to_char(struct floating_decimal_64 v, char* result) {
+static inline int fd_to_char(const struct floating_decimal_64 v, char* const result) {
   int index = 0;
   uint64_t output;
   if (v.mantissa < 0) {
@@ -242,12 +242,12 @@ static inline int fd_to_char(struct floating_decimal_64 v, char* result) {
   printf("EXP=%d\n", v.exponent + olength);
 #endif
 
-  // Print the decimal digits. This following code is equivalent to:
+  // Print the decimal digits.
+  // The following code is equivalent to:
   // for (uint32_t i = 0; i < olength - 1; ++i) {
   //   const uint32_t c = output % 10; output /= 10;
   //   result[index + olength - i] = (char) ('0' + c);
   // }
-  // // Print the leading decimal digit.
   // result[index] = '0' + output % 10;
 
   uint32_t i = 0;
@@ -536,7 +536,7 @@ int d2s_buffered_n(double f, char* result) {
   }
   // The average output length is 16.38 digits.
   // const uint32_t olength = decimalLength(output);
-  int32_t exp = e10 + removed - 1;
+  const int32_t exp = e10 + removed - 1;
 
 #ifdef RYU_DEBUG
   printf("V+=%" PRIu64 "\nV =%" PRIu64 "\nV-=%" PRIu64 "\n", vp, vr, vm);
@@ -553,7 +553,7 @@ int d2s_buffered_n(double f, char* result) {
 }
 
 void d2s_buffered(double f, char* result) {
-  int index = d2s_buffered_n(f, result);
+  const int index = d2s_buffered_n(f, result);
 
   // Terminate the string.
   result[index] = '\0';

--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -308,7 +308,7 @@ int f2s_buffered_n(float f, char* result) {
     result[index++] = '-';
   }
 
-  // Print decimal digits after the decimal point.
+  // Print the decimal digits.
   // The following code is equivalent to:
   // for (uint32_t i = 0; i < olength - 1; ++i) {
   //   const uint32_t c = output % 10; output /= 10;
@@ -369,7 +369,7 @@ int f2s_buffered_n(float f, char* result) {
 }
 
 void f2s_buffered(float f, char* result) {
-  int index = f2s_buffered_n(f, result);
+  const int index = f2s_buffered_n(f, result);
 
   // Terminate the string.
   result[index] = '\0';


### PR DESCRIPTION
This fixes a RYU_DEBUG compiler error which was recently introduced.

It also fixes MSVC warnings involving the recent addition of floating_decimal_64.

It adds const for consistency and safety.

Finally, it updates d2s/f2s comments to be consistent with each other.

