### PR TITLE
Implement round-even for the Java 32-bit implementation

### DIFF
--- a/src/test/java/info/adams/ryu/FloatToStringTest.java
+++ b/src/test/java/info/adams/ryu/FloatToStringTest.java
@@ -77,6 +77,11 @@ public abstract class FloatToStringTest {
   }
 
   @Test
+  public void roundingEvenIfTied() {
+    assertF2sEquals("0.33007812", 0.33007812f);
+  }
+
+  @Test
   public void regressionTest() {
     assertF2sEquals("4.7223665E21", 4.7223665E21f);
     assertF2sEquals("8388608.0", 8388608.0f);


### PR DESCRIPTION
There are two rounding cases; we already round even for the case where the
shortest value coincides with one of the bounds. However, we don't round even
if exact value is exactly half-way between two shortest values, i.e., if it
ends with an additional 5 digit, followed by zeroes.

Progress on #8.