### PR TITLE
Add a FLOAT80 enum, and add a -80 flag to the bit size computer

### DIFF
--- a/src/main/java/info/adams/ryu/analysis/ComputeRequiredBitSizes.java
+++ b/src/main/java/info/adams/ryu/analysis/ComputeRequiredBitSizes.java
@@ -37,7 +37,9 @@ public final class ComputeRequiredBitSizes {
     formats.add(FloatingPointFormat.FLOAT32);
     formats.add(FloatingPointFormat.FLOAT64);
     for (String s : args) {
-      if ("-128".equals(s)) {
+      if ("-80".equals(s)) {
+        formats.add(FloatingPointFormat.FLOAT80);
+      } else if ("-128".equals(s)) {
         formats.add(FloatingPointFormat.FLOAT128);
       } else if ("-256".equals(s)) {
         formats.add(FloatingPointFormat.FLOAT256);

--- a/src/main/java/info/adams/ryu/analysis/FloatingPointFormat.java
+++ b/src/main/java/info/adams/ryu/analysis/FloatingPointFormat.java
@@ -18,6 +18,7 @@ enum FloatingPointFormat {
   FLOAT16(16, 5, 10),
   FLOAT32(32, 8, 23),
   FLOAT64(64, 11, 52),
+  FLOAT80(80, 15, 63),
   FLOAT128(128, 15, 112),
   FLOAT256(256, 19, 236);
 


### PR DESCRIPTION
This might be the beginning of support for 80-bit floating point numbers, as supported on Intel and compatible CPUs/FPUs.

Minimal progress on #13.