### PR TITLE
Finish refactoring d2s.c with to_chars(), remove unnecessary casts.

### DIFF
--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -258,8 +258,8 @@ static inline struct floating_decimal_64 d2d(const uint64_t ieeeMantissa, const 
   // Implicit bool -> int conversion. True is 1, false is 0.
   const uint32_t mmShift = (m2 != (1ull << DOUBLE_MANTISSA_BITS)) || (ieeeExponent <= 1);
   // We would compute mp and mm like this:
-//  uint64_t mp = 4 * m2 + 2;
-//  uint64_t mm = mv - 1 - mmShift;
+  // uint64_t mp = 4 * m2 + 2;
+  // uint64_t mm = mv - 1 - mmShift;
 
   // Step 3: Convert to a decimal power base using 128-bit arithmetic.
   uint64_t vr, vp, vm;
@@ -408,8 +408,6 @@ static inline struct floating_decimal_64 d2d(const uint64_t ieeeMantissa, const 
     // We need to take vr+1 if vr is outside bounds or we need to round up.
     output = vr + ((vr == vm) || (lastRemovedDigit >= 5));
   }
-  // The average output length is 16.38 digits.
-  // const uint32_t olength = decimalLength(output);
   const int32_t exp = e10 + removed - 1;
 
 #ifdef RYU_DEBUG

--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -492,9 +492,9 @@ int d2s_buffered_n(double f, char* result) {
   uint32_t output2 = (uint32_t) output;
   while (output2 >= 10000) {
 #ifdef __clang__ // https://bugs.llvm.org/show_bug.cgi?id=38217
-    const uint32_t c = (uint32_t) (output2 - 10000 * (output2 / 10000));
+    const uint32_t c = output2 - 10000 * (output2 / 10000);
 #else
-    const uint32_t c = (uint32_t) (output2 % 10000);
+    const uint32_t c = output2 % 10000;
 #endif
     output2 /= 10000;
     const uint32_t c0 = (c % 100) << 1;
@@ -504,13 +504,13 @@ int d2s_buffered_n(double f, char* result) {
     i += 4;
   }
   if (output2 >= 100) {
-    const uint32_t c = (uint32_t) ((output2 % 100) << 1);
+    const uint32_t c = (output2 % 100) << 1;
     output2 /= 100;
     memcpy(result + index + olength - i - 1, DIGIT_TABLE + c, 2);
     i += 2;
   }
   if (output2 >= 10) {
-    const uint32_t c = (uint32_t) (output2 << 1);
+    const uint32_t c = output2 << 1;
     // We can't use memcpy here: the decimal dot goes between these two digits.
     result[index + olength - i] = DIGIT_TABLE[c + 1];
     result[index] = DIGIT_TABLE[c];

--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -174,8 +174,7 @@ static inline struct floating_decimal_32 f2d(const uint32_t ieeeMantissa, const 
   const uint32_t mm = 4 * m2 - (((m2 != (1u << FLOAT_MANTISSA_BITS)) || (ieeeExponent <= 1)) ? 2 : 1);
 
   // Step 3: Convert to a decimal power base using 64-bit arithmetic.
-  uint32_t vr;
-  uint32_t vp, vm;
+  uint32_t vr, vp, vm;
   int32_t e10;
   bool vmIsTrailingZeros = false;
   bool vrIsTrailingZeros = false;
@@ -298,7 +297,7 @@ static inline struct floating_decimal_32 f2d(const uint32_t ieeeMantissa, const 
   return fd;
 }
 
-static inline int to_chars(const struct floating_decimal_32 v, const bool sign, char* result) {
+static inline int to_chars(const struct floating_decimal_32 v, const bool sign, char* const result) {
   // Step 5: Print the decimal representation.
   int index = 0;
   if (sign) {
@@ -337,6 +336,7 @@ static inline int to_chars(const struct floating_decimal_32 v, const bool sign, 
   }
   if (output >= 10) {
     const uint32_t c = output << 1;
+    // We can't use memcpy here: the decimal dot goes between these two digits.
     result[index + olength - i] = DIGIT_TABLE[c + 1];
     result[index] = DIGIT_TABLE[c];
   } else {

--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -378,7 +378,7 @@ int f2s_buffered_n(float f, char* result) {
   // Decode bits into sign, mantissa, and exponent.
   const bool sign = ((bits >> (FLOAT_MANTISSA_BITS + FLOAT_EXPONENT_BITS)) & 1) != 0;
   const uint32_t ieeeMantissa = bits & ((1u << FLOAT_MANTISSA_BITS) - 1);
-  const uint32_t ieeeExponent = (uint32_t) ((bits >> FLOAT_MANTISSA_BITS) & ((1u << FLOAT_EXPONENT_BITS) - 1));
+  const uint32_t ieeeExponent = (bits >> FLOAT_MANTISSA_BITS) & ((1u << FLOAT_EXPONENT_BITS) - 1);
 
   // Case distinction; exit early for the easy cases.
   if (ieeeExponent == ((1u << FLOAT_EXPONENT_BITS) - 1u) || (ieeeExponent == 0 && ieeeMantissa == 0)) {


### PR DESCRIPTION
Finish refactoring d2s.c with to_chars() like f2s.c.

---

Remove unnecessary casts.

d2s.c: After the recent refactoring, output2 is always uint32_t, so we don't need uint32_t casts for expressions involving it.

f2s.c: This expression was already uint32_t.


---

Minor cleanups.

d2s.c: Adjust comment indentation below "We would compute mp and mm".

Remove "The average output length is 16.38 digits" comment. After the recent refactoring, the rest of this function doesn't deal with printing digits, so this comment isn't needed here. (decimalLength() still contains this comment, where it is relevant.)

Similarly, remove the commented-out definition of olength. This exact line of code appears elsewhere.

f2s.c: Like d2s.c, collapse the definitions of vr, vp, vm to a single line. (I generally prefer to avoid multiple definitions on a single line, due to how pointers etc. are parsed by the grammar, but it's reasonable for these uint32_t variables without initializers.)

Add top-level const to result.

Copy "We can't use memcpy here" comment from d2s.c.