### PR TITLE
Improve RYU_DEBUG, copy Clang workaround.

### DIFF
--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -228,7 +228,7 @@ static inline struct floating_decimal_64 d2d(const uint64_t ieeeMantissa, const 
   const uint32_t offset = (1u << (DOUBLE_EXPONENT_BITS - 1)) - 1;
 
 #ifdef RYU_DEBUG
-  uint64_t bits = (((uint64_t) ieeeExponent) << DOUBLE_MANTISSA_BITS) | ieeeMantissa;
+  const uint64_t bits = (((uint64_t) ieeeExponent) << DOUBLE_MANTISSA_BITS) | ieeeMantissa;
   printf("IN=");
   for (int32_t bit = 63; bit >= 0; --bit) {
     printf("%d", (int) ((bits >> bit) & 1));
@@ -434,8 +434,8 @@ static inline int to_chars(const struct floating_decimal_64 v, const bool sign, 
 
 #ifdef RYU_DEBUG
   printf("DIGITS=%" PRIu64 "\n", v.mantissa);
-  printf("OLEN=%d\n", olength);
-  printf("EXP=%d\n", v.exponent + olength);
+  printf("OLEN=%u\n", olength);
+  printf("EXP=%u\n", v.exponent + olength);
 #endif
 
   // Print the decimal digits.

--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -255,7 +255,13 @@ static inline struct floating_decimal_32 f2d(const uint32_t ieeeMantissa, const 
   if (vmIsTrailingZeros || vrIsTrailingZeros) {
     // General case, which happens rarely.
     while (vp / 10 > vm / 10) {
+#ifdef __clang__ // https://bugs.llvm.org/show_bug.cgi?id=23106
+      // The compiler does not realize that vm % 10 can be computed from vm / 10
+      // as vm - (vm / 10) * 10.
+      vmIsTrailingZeros &= vm - (vm / 10) * 10 == 0;
+#else
       vmIsTrailingZeros &= vm % 10 == 0;
+#endif
       vrIsTrailingZeros &= lastRemovedDigit == 0;
       lastRemovedDigit = (uint8_t) (vr % 10);
       vr /= 10;


### PR DESCRIPTION
Improve RYU_DEBUG.

* Add const.

* Fix GCC -Wformat-signedness warnings by printing uint32_t with "%u" instead of "%d".

* In f2s.c, print `e2 + 2` like d2s.c does. Fixes #47.

* Add RYU_DEBUG lines to f2s.c, appropriately modified from d2s.c.

---

Copy Clang workaround from d2s.c to f2s.c.

I observe that this improves x86 performance by 1%, although it doesn't appear to affect x64 performance.