### PR TITLE
Update f2s.c, fix signedness warnings, improve comments.

### DIFF
--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -318,7 +318,7 @@ static inline struct floating_decimal_64 d2d(const uint64_t ieeeMantissa, const 
 #endif
     if (q <= 1) {
       // {vr,vp,vm} is trailing zeros if {mv,mp,mm} has at least q trailing 0 bits.
-      // mv = 4 m2, so it always has at least two trailing 0 bits.
+      // mv = 4 * m2, so it always has at least two trailing 0 bits.
       vrIsTrailingZeros = true;
       if (acceptBounds) {
         // mm = mv - 1 - mmShift, so it has 1 trailing 0 bit iff mmShift == 1.
@@ -387,7 +387,7 @@ static inline struct floating_decimal_64 d2d(const uint64_t ieeeMantissa, const 
     printf("vr is trailing zeros=%s\n", vrIsTrailingZeros ? "true" : "false");
 #endif
     if (vrIsTrailingZeros && (lastRemovedDigit == 5) && (vr % 2 == 0)) {
-      // Round even if the exact numbers is .....50..0.
+      // Round even if the exact number is .....50..0.
       lastRemovedDigit = 4;
     }
     // We need to take vr+1 if vr is outside bounds or we need to round up.

--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -71,7 +71,7 @@ static inline bool multipleOfPowerOf5(const uint64_t value, const uint32_t p) {
 
 // Returns true if value is divisible by 2^p.
 static inline bool multipleOfPowerOf2(const uint64_t value, const uint32_t p) {
-  // return __builtin_ctz(value) >= p;
+  // return __builtin_ctzll(value) >= p;
   return (value & ((1ull << p) - 1)) == 0;
 }
 

--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -53,8 +53,8 @@
 #include "ryu/digit_table.h"
 #include "ryu/d2s.h"
 
-static inline int32_t pow5Factor(uint64_t value) {
-  for (int32_t count = 0; value > 0; ++count) {
+static inline uint32_t pow5Factor(uint64_t value) {
+  for (uint32_t count = 0; value > 0; ++count) {
     if (value % 5 != 0) {
       return count;
     }
@@ -278,7 +278,7 @@ static inline struct floating_decimal_64 d2d(const uint64_t ieeeMantissa, const 
     vr = mulShiftAll(m2, DOUBLE_POW5_INV_SPLIT[q], i, &vp, &vm, mmShift);
 #endif
 #ifdef RYU_DEBUG
-    printf("%" PRIu64 " * 2^%d / 10^%d\n", mv, e2, q);
+    printf("%" PRIu64 " * 2^%d / 10^%u\n", mv, e2, q);
     printf("V+=%" PRIu64 "\nV =%" PRIu64 "\nV-=%" PRIu64 "\n", vp, vr, vm);
 #endif
     if (q <= 21) {
@@ -312,8 +312,8 @@ static inline struct floating_decimal_64 d2d(const uint64_t ieeeMantissa, const 
     vr = mulShiftAll(m2, DOUBLE_POW5_SPLIT[i], j, &vp, &vm, mmShift);
 #endif
 #ifdef RYU_DEBUG
-    printf("%" PRIu64 " * 5^%d / 10^%d\n", mv, -e2, q);
-    printf("%d %d %d %d\n", q, i, k, j);
+    printf("%" PRIu64 " * 5^%d / 10^%u\n", mv, -e2, q);
+    printf("%u %d %d %d\n", q, i, k, j);
     printf("V+=%" PRIu64 "\nV =%" PRIu64 "\nV-=%" PRIu64 "\n", vp, vr, vm);
 #endif
     if (q <= 1) {

--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -162,6 +162,7 @@ static inline struct floating_decimal_32 f2d(const uint32_t ieeeMantissa, const 
   // Step 2: Determine the interval of legal decimal representations.
   const uint32_t mv = 4 * m2;
   const uint32_t mp = 4 * m2 + 2;
+  // Implicit bool -> int conversion. True is 1, false is 0.
   const uint32_t mmShift = (m2 != (1u << FLOAT_MANTISSA_BITS)) || (ieeeExponent <= 1);
   const uint32_t mm = 4 * m2 - 1 - mmShift;
 

--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -163,7 +163,7 @@ static inline struct floating_decimal_32 f2d(const uint32_t ieeeMantissa, const 
   const uint32_t mv = 4 * m2;
   const uint32_t mp = 4 * m2 + 2;
   // Implicit bool -> int conversion. True is 1, false is 0.
-  const uint32_t mmShift = (m2 != (1u << FLOAT_MANTISSA_BITS)) || (ieeeExponent <= 1);
+  const uint32_t mmShift = (ieeeMantissa != 0) || (ieeeExponent <= 1);
   const uint32_t mm = 4 * m2 - 1 - mmShift;
 
   // Step 3: Convert to a decimal power base using 64-bit arithmetic.
@@ -413,17 +413,17 @@ int f2s_buffered_n(float f, char* result) {
 #endif
 
   // Decode bits into sign, mantissa, and exponent.
-  const bool sign = ((bits >> (FLOAT_MANTISSA_BITS + FLOAT_EXPONENT_BITS)) & 1) != 0;
+  const bool ieeeSign = ((bits >> (FLOAT_MANTISSA_BITS + FLOAT_EXPONENT_BITS)) & 1) != 0;
   const uint32_t ieeeMantissa = bits & ((1u << FLOAT_MANTISSA_BITS) - 1);
   const uint32_t ieeeExponent = (bits >> FLOAT_MANTISSA_BITS) & ((1u << FLOAT_EXPONENT_BITS) - 1);
 
   // Case distinction; exit early for the easy cases.
   if (ieeeExponent == ((1u << FLOAT_EXPONENT_BITS) - 1u) || (ieeeExponent == 0 && ieeeMantissa == 0)) {
-    return copy_special_str(result, sign, ieeeExponent, ieeeMantissa);
+    return copy_special_str(result, ieeeSign, ieeeExponent, ieeeMantissa);
   }
 
   const struct floating_decimal_32 v = f2d(ieeeMantissa, ieeeExponent);
-  return to_chars(v, sign, result);
+  return to_chars(v, ieeeSign, result);
 }
 
 void f2s_buffered(float f, char* result) {

--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -312,7 +312,7 @@ static inline struct floating_decimal_32 f2d(const uint32_t ieeeMantissa, const 
     // We need to take vr+1 if vr is outside bounds or we need to round up.
     output = vr + ((vr == vm) || (lastRemovedDigit >= 5));
   }
-  const int32_t exp = e10 + removed - 1;
+  const int32_t exp = e10 + removed;
 
 #ifdef RYU_DEBUG
   printf("V+=%u\nV =%u\nV-=%u\n", vp, vr, vm);
@@ -388,7 +388,7 @@ static inline int to_chars(const struct floating_decimal_32 v, const bool sign, 
 
   // Print the exponent.
   result[index++] = 'E';
-  int32_t exp = v.exponent + olength;
+  int32_t exp = v.exponent + olength - 1;
   if (exp < 0) {
     result[index++] = '-';
     exp = -exp;


### PR DESCRIPTION
This ports commits 6dd24a5, d5e4cd4, 87d807b, fab5f9d, and 4990e0f from d2s.c to f2s.c.

---

Fix signedness warnings.

Changing pow5Factor() to return uint32_t fixes MSVC warning C4018 "'>=': signed/unsigned mismatch" and Clang -Wsign-compare "warning: comparison of integers of different signs: 'int32_t' (aka 'int') and 'const uint32_t' (aka 'const unsigned int')".

Also fix GCC -Wformat-signedness by using %u to print uint32_t q.

---

Improve comments.

Copy mmShift comment from d2s.c to f2s.c.

In d2s.c multipleOfPowerOf2(), change the commented intrinsic from __builtin_ctz to __builtin_ctzll, which would correctly handle uint64_t value.

Change "mv = 4 m2" to "mv = 4 * m2" to match the source code.

Fix "exact number" pluralization.