### PR TITLE
Add F2sTest LooksLikePow5.

### DIFF
--- a/ryu/tests/f2s_test.cc
+++ b/ryu/tests/f2s_test.cc
@@ -106,6 +106,15 @@ TEST(F2sTest, Regression) {
   ASSERT_STREQ("3.3554432E7", f2s(3.3554432E7f));
 }
 
+TEST(F2sTest, LooksLikePow5) {
+  // These numbers have a mantissa that is the largest power of 5 that fits,
+  // and an exponent that causes the computation for q to result in 10, which is a corner
+  // case for Ryu.
+  ASSERT_STREQ("6.7108864E17", f2s(int32Bits2Float(0x5D1502F9)));
+  ASSERT_STREQ("1.3421773E18", f2s(int32Bits2Float(0x5D9502F9)));
+  ASSERT_STREQ("2.6843546E18", f2s(int32Bits2Float(0x5E1502F9)));
+}
+
 TEST(F2sTest, OutputLength) {
   ASSERT_STREQ("1E0", f2s(1.0f)); // already tested in Basic
   ASSERT_STREQ("1.2E0", f2s(1.2f));


### PR DESCRIPTION
I constructed these inputs and outputs by hand (with assistance from
Wolfram Alpha) and verified via debugging that q == 10.

The inputs, converted from hex to binary, are:

0 10111010 00101010000001011111001
0 10111011 00101010000001011111001
0 10111100 00101010000001011111001

The mantissas are identical. After restoring the implicit leading bit,
this is 100101010000001011111001 in binary, or 9765625 in decimal,
which is 5^10. No multiples are possible: 5^10 is less than 2^24,
but 2 * 5^10 is greater.

The exponents in decimal are 186, 187, and 188, determined by solving
for q == 10:

q = log10Pow2(e2);
q = floor(log_10(2^e2)); (using the exact form, not the approximation)
Our ieeeExponent is nonzero, so:
e2 = ieeeExponent - bias - FLOAT_MANTISSA_BITS - 2;
e2 = ieeeExponent - 127 - 23 - 2;
e2 = ieeeExponent - 152;
q = floor(log_10(2^(ieeeExponent - 152)));
WA: integer solutions of floor(log_10(2^(x - 152))) = 10

For the outputs, I looked at the surrounding floats with:

WA: Table[2^(n-127-23)*(5^10+k),{n,186,188},{k,-1,1}]

671088571280523264
671088640000000000
671088708719476736

1342177142561046528
1342177280000000000
1342177417438953472

2684354285122093056
2684354560000000000
2684354834877906944

This allowed me to manually round them.