### PR TITLE
Move float/double to bits conversion to a helper method

### DIFF
--- a/ryu/common.h
+++ b/ryu/common.h
@@ -62,4 +62,16 @@ static inline int copy_special_str(char * const result, const bool sign, const b
   return sign + 3;
 }
 
+static inline uint32_t float_to_bits(float f) {
+  uint32_t bits = 0;
+  memcpy(&bits, &f, sizeof(float));
+  return bits;
+}
+
+static inline uint64_t double_to_bits(double d) {
+  uint64_t bits = 0;
+  memcpy(&bits, &d, sizeof(double));
+  return bits;
+}
+
 #endif // RYU_COMMON_H

--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -536,9 +536,7 @@ static inline int to_chars(const struct floating_decimal_64 v, const bool sign, 
 
 int d2s_buffered_n(double f, char* result) {
   // Step 1: Decode the floating-point number, and unify normalized and subnormal cases.
-  uint64_t bits = 0;
-  // This only works on little-endian architectures.
-  memcpy(&bits, &f, sizeof(double));
+  uint64_t bits = double_to_bits(f);
 
 #ifdef RYU_DEBUG
   printf("IN=");

--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -406,9 +406,7 @@ static inline int to_chars(const struct floating_decimal_32 v, const bool sign, 
 
 int f2s_buffered_n(float f, char* result) {
   // Step 1: Decode the floating-point number, and unify normalized and subnormal cases.
-  uint32_t bits = 0;
-  // This only works on little-endian architectures.
-  memcpy(&bits, &f, sizeof(float));
+  uint32_t bits = float_to_bits(f);
 
 #ifdef RYU_DEBUG
   printf("IN=");


### PR DESCRIPTION
Remove the comments that refered to big-endian architectures - it should work
just fine as long as float and int use the same endianness.

Closes #3.