### PR TITLE
benchmark.cc: Add const, use std::mt19937_64.

### DIFF
--- a/ryu/benchmark/benchmark.cc
+++ b/ryu/benchmark/benchmark.cc
@@ -108,7 +108,7 @@ static int bench32(int samples, int iterations, bool verbose) {
   init(mv2);
   int throwaway = 0;
   for (int i = 0; i < samples; i++) {
-    uint32_t r = mt32();
+    const uint32_t r = mt32();
     float f = int32Bits2Float(r);
 
     steady_clock::time_point t1 = steady_clock::now();
@@ -150,16 +150,14 @@ static int bench32(int samples, int iterations, bool verbose) {
 
 static int bench64(int samples, int iterations, bool verbose) {
   char* bufferown = (char*) calloc(BUFFER_SIZE, sizeof(char));
-  std::mt19937 mt32(12345);
+  std::mt19937_64 mt64(12345);
   mean_and_variance mv1;
   mean_and_variance mv2;
   init(mv1);
   init(mv2);
   int throwaway = 0;
   for (int i = 0; i < samples; i++) {
-    uint64_t r = mt32();
-    r <<= 32;
-    r |= mt32(); // calling mt32() in separate statements guarantees order of evaluation
+    const uint64_t r = mt64();
     double f = int64Bits2Double(r);
 
     steady_clock::time_point t1 = steady_clock::now();


### PR DESCRIPTION
Accepting #63 will change bench32()'s timings (in a desirable way). That makes this a good time to simplify bench64() (changing its timings in a minor, neutral way).

Instead of calling a 32-bit Mersenne Twister twice, which exactly replicated the previous third-party implementation, we can simply use the Standard's 64-bit Mersenne Twister. It generates every uint64_t with equal probability, so the test is essentially unaffected. (The exact values differ from the previous technique, so the timings might change very slightly, as if a different seed were chosen.)

Calling std::mt19937 twice versus calling std::mt19937_64 once has somewhat different performance characteristics, but the benchmark doesn't time this, so it doesn't matter.