### PR TITLE
d2s.c: Further improve x86 perf.

### DIFF
--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -255,7 +255,7 @@ static inline floating_decimal_32 f2d(const uint32_t ieeeMantissa, const uint32_
   uint32_t removed = 0;
   uint32_t output;
   if (vmIsTrailingZeros || vrIsTrailingZeros) {
-    // General case, which happens rarely.
+    // General case, which happens rarely (~4.0%).
     while (vp / 10 > vm / 10) {
 #ifdef __clang__ // https://bugs.llvm.org/show_bug.cgi?id=23106
       // The compiler does not realize that vm % 10 can be computed from vm / 10
@@ -297,7 +297,9 @@ static inline floating_decimal_32 f2d(const uint32_t ieeeMantissa, const uint32_
     output = vr +
         ((vr == vm && (!acceptBounds || !vmIsTrailingZeros)) || lastRemovedDigit >= 5);
   } else {
-    // Common case.
+    // Specialized for the common case (~96.0%). Percentages below are relative to this.
+    // Loop iterations below (approximately):
+    // 0: 13.6%, 1: 70.7%, 2: 14.1%, 3: 1.39%, 4: 0.14%, 5+: 0.01%
     while (vp / 10 > vm / 10) {
       lastRemovedDigit = (uint8_t) (vr % 10);
       vr /= 10;


### PR DESCRIPTION
On Reddit, the user Veedrac mentioned that my `while (vp - vm >= 1000)` loop never activated. Oops! I confirmed this (0 activations, for 1 billion random doubles), and instrumented the control flow to understand what was happening. (I've rediscovered the story behind the existing comment "On average, we remove ~2 digits.")

Although that loop was dead weight, my previous PR improved performance due to the `if (vp - vm >= 100)` branch. This is successful ~60.3% of the time (out of control flow that passes through the common case).

An even larger improvement is possible. The idea behind my subtraction optimization was that its inexactness (it misses cases when two digits can be removed) was counterbalanced by its cheapness when false (ignoring branch misprediction, it doesn't cost any divisions by constants).

It turns out that an exact test, `if (vp / 100 > vm / 100)`, is superior. This is successful ~86.2% of the time. Its exactness (reducing how many iterations of `while (vp / 10 > vm / 10)` are required, down to zero 70.6% of the time) outweighs its expense when false (~13.8% of the time, we pay the divisions by 100 for no benefit).

Here's a table of how many `while (vp / 10 > vm / 10)` iterations are performed, for the original code (no optimization), the inexact subtraction optimization, and the exact division optimization. (The original and division numbers are captured in code comments; subtraction is mentioned here but not in the code as it's a dead end.)

| Original  | Subtract  | Divide    |
| --------- | --------- | --------- |
| 0:  0.03% | 0:  47.3% | 0:  70.6% |
| 1:  13.8% | 1:  25.5% | 1:  27.8% |
| 2:  70.6% | 2:  24.5% | 2:  1.40% |
| 3:  14.0% | 3:  2.45% | 3:  0.14% |
| 4:  1.40% | 4:  0.24% | 4+: 0.02% |
| 5:  0.14% | 5+: 0.03% |           |
| 6+: 0.02% |           |           |

I've also updated d2s.c and f2s.c with more precise control flow percentages (obtained by testing 1 billion doubles/floats). This revealed why my optimization wasn't applicable to floats: most of the time, only one digit is removed.

Benchmarks with Clang 7.0.0 RC1:

```
C:\Temp\TESTING_X86>1_original\benchmark_clang -samples=100000 -64
    Average & Stddev Ryu  Average & Stddev Grisu3
64:  118.638   13.609      186.448  137.493

C:\Temp\TESTING_X86>2_minus_opt\benchmark_clang -samples=100000 -64
    Average & Stddev Ryu  Average & Stddev Grisu3
64:  107.669   14.269      188.093  137.811

C:\Temp\TESTING_X86>3_div_opt\benchmark_clang -samples=100000 -64
    Average & Stddev Ryu  Average & Stddev Grisu3
64:  100.614   10.937      191.804  137.520
```

Compared to the original code, this is a 17.9% improvement for x86. It's a 7.0% improvement compared to the subtraction optimization.

```
C:\Temp\TESTING_X64>1_original\benchmark_clang -samples=100000 -64
    Average & Stddev Ryu  Average & Stddev Grisu3
64:   31.350    1.875      107.548  103.044

C:\Temp\TESTING_X64>2_minus_opt\benchmark_clang -samples=100000 -64
    Average & Stddev Ryu  Average & Stddev Grisu3
64:   30.934    1.841      107.560  103.094

C:\Temp\TESTING_X64>3_div_opt\benchmark_clang -samples=100000 -64
    Average & Stddev Ryu  Average & Stddev Grisu3
64:   30.762    1.950      108.818  108.994
```

Compared to the original code, this is a 1.9% improvement for x64.