### PR TITLE
Slightly simplify pow5Factor

### DIFF
--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -54,13 +54,18 @@
 #include "ryu/d2s.h"
 
 static inline uint32_t pow5Factor(uint64_t value) {
-  for (uint32_t count = 0; value > 0; ++count) {
-    if (value % 5 != 0) {
-      return count;
+  uint32_t count = 0;
+  for (;;) {
+    assert(value != 0);
+    const uint64_t q = value / 5;
+    const uint64_t r = value % 5;
+    if (r != 0) {
+      break;
     }
-    value /= 5;
+    value = q;
+    ++count;
   }
-  return 0;
+  return count;
 }
 
 // Returns true if value is divisible by 5^p.


### PR DESCRIPTION
On entry, value is non-zero. We then compute the remainder r = value % 5
and test for non-zero. If this test is false, i.e., r == 0, then we must
have q = value / 5 != 0.

The test for 'value > 0' can therefore be removed.