### PR TITLE
Improve benchmark.cc, adding -ryu and -invert options.

### DIFF
--- a/ryu/benchmark/benchmark.cc
+++ b/ryu/benchmark/benchmark.cc
@@ -37,8 +37,8 @@ using double_conversion::StringBuilder;
 using double_conversion::DoubleToStringConverter;
 using namespace std::chrono;
 
-static int BUFFER_SIZE = 40;
-static char* buffer = (char*) calloc(BUFFER_SIZE, sizeof(char));
+constexpr int BUFFER_SIZE = 40;
+static char buffer[BUFFER_SIZE];
 static DoubleToStringConverter converter(
     DoubleToStringConverter::Flags::EMIT_TRAILING_DECIMAL_POINT
         | DoubleToStringConverter::Flags::EMIT_TRAILING_ZERO_AFTER_POINT,
@@ -100,7 +100,7 @@ double variance(mean_and_variance &mv) {
 }
 
 static int bench32(int samples, int iterations, bool verbose) {
-  char* bufferown = (char*) calloc(BUFFER_SIZE, sizeof(char));
+  char bufferown[BUFFER_SIZE];
   std::mt19937 mt32(12345);
   mean_and_variance mv1;
   mean_and_variance mv2;
@@ -146,7 +146,7 @@ static int bench32(int samples, int iterations, bool verbose) {
 }
 
 static int bench64(int samples, int iterations, bool verbose) {
-  char* bufferown = (char*) calloc(BUFFER_SIZE, sizeof(char));
+  char bufferown[BUFFER_SIZE];
   std::mt19937 mt32(12345);
   mean_and_variance mv1;
   mean_and_variance mv2;

--- a/ryu/benchmark/benchmark.cc
+++ b/ryu/benchmark/benchmark.cc
@@ -51,16 +51,16 @@ static DoubleToStringConverter converter(
     0);
 static StringBuilder builder(buffer, BUFFER_SIZE);
 
-char* fcv(float value) {
+void fcv(float value) {
   builder.Reset();
   converter.ToShortestSingle(value, &builder);
-  return builder.Finalize();
+  builder.Finalize();
 }
 
-char* dcv(double value) {
+void dcv(double value) {
   builder.Reset();
   converter.ToShortest(value, &builder);
-  return builder.Finalize();
+  builder.Finalize();
 }
 
 static float int32Bits2Float(uint32_t bits) {
@@ -132,10 +132,8 @@ static int bench32(int samples, int iterations, bool verbose) {
       printf("%u,%lf,%lf\n", r, delta1, delta2);
     }
 
-    char* own = bufferown;
-    char* theirs = fcv(f);
-    if (strcmp(own, theirs) != 0) {
-      printf("For %x %20s %20s\n", r, own, theirs);
+    if (strcmp(bufferown, buffer) != 0) {
+      printf("For %x %20s %20s\n", r, bufferown, buffer);
     }
   }
   if (!verbose) {
@@ -180,10 +178,8 @@ static int bench64(int samples, int iterations, bool verbose) {
       printf("%" PRIu64 ",%lf,%lf\n", r, delta1, delta2);
     }
 
-    char* own = bufferown;
-    char* theirs = dcv(f);
-    if (strcmp(own, theirs) != 0) {
-      printf("For %16" PRIX64 " %28s %28s\n", r, own, theirs);
+    if (strcmp(bufferown, buffer) != 0) {
+      printf("For %16" PRIX64 " %28s %28s\n", r, bufferown, buffer);
     }
   }
   if (!verbose) {

--- a/ryu/benchmark/benchmark.cc
+++ b/ryu/benchmark/benchmark.cc
@@ -99,7 +99,7 @@ double variance(mean_and_variance &mv) {
   return mv.m2 / (mv.n - 1);
 }
 
-static int bench32(int samples, int iterations, bool verbose) {
+static int bench32(int samples, int iterations, bool verbose, bool ryu_only) {
   char bufferown[BUFFER_SIZE];
   std::mt19937 mt32(12345);
   mean_and_variance mv1;
@@ -121,18 +121,21 @@ static int bench32(int samples, int iterations, bool verbose) {
     update(mv1, delta1);
 
     t1 = steady_clock::now();
-    for (int j = 0; j < iterations; ++j) {
-      fcv(f);
-      throwaway += buffer[2];
+    if (!ryu_only) {
+      for (int j = 0; j < iterations; ++j) {
+        fcv(f);
+        throwaway += buffer[2];
+      }
     }
     t2 = steady_clock::now();
     double delta2 = duration_cast<nanoseconds>(t2 - t1).count() / static_cast<double>(iterations);
     update(mv2, delta2);
+
     if (verbose) {
       printf("%u,%lf,%lf\n", r, delta1, delta2);
     }
 
-    if (strcmp(bufferown, buffer) != 0) {
+    if (!ryu_only && strcmp(bufferown, buffer) != 0) {
       printf("For %x %20s %20s\n", r, bufferown, buffer);
     }
   }
@@ -143,7 +146,7 @@ static int bench32(int samples, int iterations, bool verbose) {
   return throwaway;
 }
 
-static int bench64(int samples, int iterations, bool verbose) {
+static int bench64(int samples, int iterations, bool verbose, bool ryu_only) {
   char bufferown[BUFFER_SIZE];
   std::mt19937 mt32(12345);
   mean_and_variance mv1;
@@ -167,18 +170,21 @@ static int bench64(int samples, int iterations, bool verbose) {
     update(mv1, delta1);
 
     t1 = steady_clock::now();
-    for (int j = 0; j < iterations; ++j) {
-      dcv(f);
-      throwaway += buffer[2];
+    if (!ryu_only) {
+      for (int j = 0; j < iterations; ++j) {
+        dcv(f);
+        throwaway += buffer[2];
+      }
     }
     t2 = steady_clock::now();
     double delta2 = duration_cast<nanoseconds>(t2 - t1).count() / static_cast<double>(iterations);
     update(mv2, delta2);
+
     if (verbose) {
       printf("%" PRIu64 ",%lf,%lf\n", r, delta1, delta2);
     }
 
-    if (strcmp(bufferown, buffer) != 0) {
+    if (!ryu_only && strcmp(bufferown, buffer) != 0) {
       printf("For %16" PRIX64 " %28s %28s\n", r, bufferown, buffer);
     }
   }
@@ -206,6 +212,7 @@ int main(int argc, char** argv) {
   int samples = 10000;
   int iterations = 1000;
   bool verbose = false;
+  bool ryu_only = false;
   for (int i = 1; i < argc; ++i) {
     if (strcmp(argv[i], "-32") == 0) {
       run32 = true;
@@ -215,6 +222,8 @@ int main(int argc, char** argv) {
       run64 = true;
     } else if (strcmp(argv[i], "-v") == 0) {
       verbose = true;
+    } else if (strcmp(argv[i], "-ryu") == 0) {
+      ryu_only = true;
     } else if (strncmp(argv[i], "-samples=", 9) == 0) {
       sscanf(argv[i], "-samples=%i", &samples);
     } else if (strncmp(argv[i], "-iterations=", 12) == 0) {
@@ -234,10 +243,10 @@ int main(int argc, char** argv) {
   }
   int throwaway = 0;
   if (run32) {
-    throwaway += bench32(samples, iterations, verbose);
+    throwaway += bench32(samples, iterations, verbose, ryu_only);
   }
   if (run64) {
-    throwaway += bench64(samples, iterations, verbose);
+    throwaway += bench64(samples, iterations, verbose, ryu_only);
   }
   if (argc == 1000) {
     // Prevent the compiler from optimizing the code away.

--- a/ryu/benchmark/benchmark.cc
+++ b/ryu/benchmark/benchmark.cc
@@ -75,11 +75,11 @@ static double int64Bits2Double(uint64_t bits) {
   return f;
 }
 
-typedef struct {
+struct mean_and_variance {
   int64_t n;
   double mean;
   double m2;
-} mean_and_variance;
+};
 
 void init(mean_and_variance &mv) {
   mv.n = 0;
@@ -107,26 +107,26 @@ static int bench32(int samples, int iterations, bool verbose) {
   init(mv1);
   init(mv2);
   int throwaway = 0;
-  for (int i = 0; i < samples; i++) {
+  for (int i = 0; i < samples; ++i) {
     uint32_t r = mt32();
     float f = int32Bits2Float(r);
 
-    steady_clock::time_point t1 = steady_clock::now();
-    for (int j = 0; j < iterations; j++) {
+    auto t1 = steady_clock::now();
+    for (int j = 0; j < iterations; ++j) {
       f2s_buffered(f, bufferown);
       throwaway += bufferown[2];
     }
-    steady_clock::time_point t2 = steady_clock::now();
-    double delta1 = duration_cast<nanoseconds>( t2 - t1 ).count() / (double) iterations;
+    auto t2 = steady_clock::now();
+    double delta1 = duration_cast<nanoseconds>(t2 - t1).count() / static_cast<double>(iterations);
     update(mv1, delta1);
 
     t1 = steady_clock::now();
-    for (int j = 0; j < iterations; j++) {
+    for (int j = 0; j < iterations; ++j) {
       fcv(f);
       throwaway += buffer[2];
     }
     t2 = steady_clock::now();
-    double delta2 = duration_cast<nanoseconds>( t2 - t1 ).count() / (double) iterations;
+    double delta2 = duration_cast<nanoseconds>(t2 - t1).count() / static_cast<double>(iterations);
     update(mv2, delta2);
     if (verbose) {
       printf("%u,%lf,%lf\n", r, delta1, delta2);
@@ -151,28 +151,28 @@ static int bench64(int samples, int iterations, bool verbose) {
   init(mv1);
   init(mv2);
   int throwaway = 0;
-  for (int i = 0; i < samples; i++) {
+  for (int i = 0; i < samples; ++i) {
     uint64_t r = mt32();
     r <<= 32;
     r |= mt32(); // calling mt32() in separate statements guarantees order of evaluation
     double f = int64Bits2Double(r);
 
-    steady_clock::time_point t1 = steady_clock::now();
-    for (int j = 0; j < iterations; j++) {
+    auto t1 = steady_clock::now();
+    for (int j = 0; j < iterations; ++j) {
       d2s_buffered(f, bufferown);
       throwaway += bufferown[2];
     }
-    steady_clock::time_point t2 = steady_clock::now();
-    double delta1 = duration_cast<nanoseconds>( t2 - t1 ).count() / (double) iterations;
+    auto t2 = steady_clock::now();
+    double delta1 = duration_cast<nanoseconds>(t2 - t1).count() / static_cast<double>(iterations);
     update(mv1, delta1);
 
     t1 = steady_clock::now();
-    for (int j = 0; j < iterations; j++) {
+    for (int j = 0; j < iterations; ++j) {
       dcv(f);
       throwaway += buffer[2];
     }
     t2 = steady_clock::now();
-    double delta2 = duration_cast<nanoseconds>( t2 - t1 ).count() / (double) iterations;
+    double delta2 = duration_cast<nanoseconds>(t2 - t1).count() / static_cast<double>(iterations);
     update(mv2, delta2);
     if (verbose) {
       printf("%" PRIu64 ",%lf,%lf\n", r, delta1, delta2);
@@ -206,7 +206,7 @@ int main(int argc, char** argv) {
   int samples = 10000;
   int iterations = 1000;
   bool verbose = false;
-  for (int i = 1; i < argc; i++) {
+  for (int i = 1; i < argc; ++i) {
     if (strcmp(argv[i], "-32") == 0) {
       run32 = true;
       run64 = false;

--- a/ryu/benchmark/benchmark.cc
+++ b/ryu/benchmark/benchmark.cc
@@ -134,9 +134,6 @@ static int bench32(int samples, int iterations, bool verbose) {
 
     char* own = bufferown;
     char* theirs = fcv(f);
-    if (throwaway == 12345) {
-      printf("Argh!\n");
-    }
     if (strcmp(own, theirs) != 0) {
       printf("For %x %20s %20s\n", r, own, theirs);
     }


### PR DESCRIPTION
This contains several improvements for benchmark.cc, grouped into separate commits for ease of reviewing. There are two new features:

* A `-ryu` option to run only Ryu without Grisu3. This is a time-saver when profiling Ryu changes.

* An `-invert` option to switch the sample/iteration loops. This should help to understand the impact of branch (mis)prediction on Ryu.

Commit notes:

---

benchmark.cc: Drop `if (throwaway == 12345)`.

This code was present in the float benchmarking, but not double. I suspect that it was a relic of an earlier era when throwaway wasn't returned to main() for inspection.

---

benchmark.cc: constexpr BUFFER_SIZE, avoid calloc().

BUFFER_SIZE should be a compile-time constant, not a modifiable global variable.

Instead of dynamically allocating memory (and never freeing it), it's simpler to make buffer a global array and bufferown a local array on the stack.

---

benchmark.cc: Simplify fcv() and dcv().

Part of the code already assumes that fcv() and dcv() update buffer. Instead of calling them again, we can simply compare bufferown and buffer to verify that Ryu and Grisu3 produce identical output.

---

benchmark.cc: Improve C++ style.

Directly name `struct mean_and_variance`.

Prefer preincrement.

Use auto for steady_clock::time_point (which is verbose, and type-safe, so there's little risk of getting confused about what it is).

Use static_cast.

---

benchmark.cc: Add "-ryu" for Ryu-only mode.

This mode still prints Grisu3 stats, as near-zero garbage. (Fixed by a later commit.)

---

benchmark.cc: mean_and_variance member functions.

This replaces init() with C++11 default member initializers (less verbose than a constructor), changes update() and variance() into member functions, and adds stddev() so sqrt() doesn't need to be repeated later.

One subtlety: Previously, update() said `int64_t n = ++mv.n;` and later read this local variable. Because this preincremented the data member before storing the local variable, and nothing else is happening, we can drop the local variable and simply read the data member.

---

benchmark.cc: Add "-invert" to switch loops.

Normally, the benchmark generates samples in an outer loop, and then it tests each sample in an inner loop for iterations. This allows mean and variance statistics to be collected for each sample, which is useful because some samples exercise different codepaths.

However, repeatedly testing each sample causes Ryu's branches to be highly predictable, which is unrealistic for the real world.

The new "-invert" option generates samples into a std::vector (to keep the Mersenne Twister out of the profiling). Then it has an outer loop for iterations, and its inner loop tests each sample once. This has realistic branch (mis)prediction characteristics.

Note that when inverting, we divide the t2 - t1 duration (which is the total time taken to convert all samples in the vector) by samples, so the delta is the average time taken to convert a sample. This means that the printed Average values are comparable between normal mode and inverted mode (and the difference shows how costly branch misprediction is). The printed Stddev values aren't comparable, though - in normal mode, they measure the variation between samples (which is nonzero, even for an ideal machine, because Ryu does different amounts of work for different inputs), while in inverted mode, they measure the variation between each vector loop (which would ideally be zero for a perfectly deterministic machine).

Example output:

```
C:\Temp\TESTING_X64>benchmark_clang
    Average & Stddev Ryu  Average & Stddev Grisu3
32:   19.561    1.811       91.689   52.230
64:   29.868    1.882      106.720   89.150

C:\Temp\TESTING_X64>benchmark_clang -invert
    Average & Stddev Ryu  Average & Stddev Grisu3
32:   31.694    1.187      117.464    4.087
64:   42.507    0.963      131.933    1.514
```

---

benchmark.cc: Improve "-ryu" and "-invert" output.

This avoids printing unnecessary fields.