### PR TITLE
Centralize RYU_32_BIT_PLATFORM and optimize shiftright128().

### DIFF
--- a/ryu/common.h
+++ b/ryu/common.h
@@ -20,6 +20,10 @@
 #include <assert.h>
 #include <stdint.h>
 
+#if defined(_M_IX86) || defined(_M_ARM)
+#define RYU_32_BIT_PLATFORM
+#endif
+
 // Returns e == 0 ? 1 : ceil(log_2(5^e)).
 static inline uint32_t pow5bits(const int32_t e) {
   // This approximation works up to the point that the multiplication overflows at e = 3529.

--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -103,7 +103,7 @@ static inline uint32_t mulShift(const uint32_t m, const uint64_t factor, const i
   const uint64_t bits0 = (uint64_t)m * factorLo;
   const uint64_t bits1 = (uint64_t)m * factorHi;
 
-#if defined(_M_IX86) || defined(_M_ARM)
+#ifdef RYU_32_BIT_PLATFORM
   // On 32-bit platforms we can avoid a 64-bit shift-right since we only
   // need the upper 32 bits of the result and the shift value is > 32.
   const uint32_t bits0Hi = (uint32_t)(bits0 >> 32);
@@ -113,12 +113,12 @@ static inline uint32_t mulShift(const uint32_t m, const uint64_t factor, const i
   bits1Hi += (bits1Lo < bits0Hi);
   const int32_t s = shift - 32;
   return (bits1Hi << (32 - s)) | (bits1Lo >> s);
-#else
+#else // RYU_32_BIT_PLATFORM
   const uint64_t sum = (bits0 >> 32) + bits1;
   const uint64_t shiftedSum = sum >> (shift - 32);
   assert(shiftedSum <= UINT32_MAX);
   return (uint32_t) shiftedSum;
-#endif
+#endif // RYU_32_BIT_PLATFORM
 }
 
 static inline uint32_t mulPow5InvDivPow2(const uint32_t m, const uint32_t q, const int32_t j) {


### PR DESCRIPTION
* common.h: Centralize RYU_32_BIT_PLATFORM. This indicates whether we should avoid uint64_t operations for performance, and is activated by the MSVC platform macros _M_IX86 and _M_ARM (also defined by Clang on Windows). This centralization will make it easier to detect additional platforms as 32-bit. Note that if a 32-bit platform isn't detected here, the consequences are limited to performance, as Ryu will use correct-but-slower uint64_t operations.

* d2s_intrinsics.h: Include common.h for RYU_32_BIT_PLATFORM.

* Fix comment, as the shift value can be 49. (Example: `r = 0xba6fa7161a4d6e0c` with `ieeeMantissa = 0x000fa7161a4d6e0c` and `ieeeExponent = 0x000003a6`.) I've experimentally observed that the upper bound might be 57 instead of 58, but I can't prove that theoretically.

* Optimize shiftright128() for 32-bit platforms. If we can assume `dist >= 32` (which the optimizer can't see), then we can grab lo's most significant 32 bits with `(uint32_t)(lo >> 32)` (32-bit compilers can do this efficiently), and then perform a 32-bit shift for the remaining `(dist - 32)`. Additionally, `uint64_t | uint32_t` is less work. I observe that this improves Clang 7 RC1 perf by 2.8% (80.382 ns improved to 78.193 ns) which seems nice for such a small, localized change. I also observe that this degrades MSVC perf by 0.6% (106.155 ns degraded to 106.759 ns), but (1) that's very small and (2) Clang is an existence proof that MSVC can do better (tracked by VSO#634761).

* Extend `#if defined(_M_IX86)` to `#ifdef RYU_32_BIT_PLATFORM` and update comments accordingly. This extends the division-by-64-bit-constant workaround to ARM32 (for which LLVM#37932 was originally filed).

* f2s.c: This already includes common.h, so we can use RYU_32_BIT_PLATFORM with no behavioral changes.