### PR TITLE
Add github.com/cespare/ryu to list of implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ My PLDI'18 paper includes a complete correctness proof of the algorithm:
 https://dl.acm.org/citation.cfm?id=3192369, available under the creative commons
 CC-BY-SA license.
 
-Andriy Plokhotnyuk developed a scala implementation that is available here:
-https://github.com/plokhotnyuk/jsoniter-scala
+Other implementations:
 
-Mara Bos provides a Rust wrapper of the C code here:
-https://docs.rs/ryu/0.1.1/ryu/
-
-Julia version: https://github.com/quinnj/Ryu.jl
-
-Factor version: https://github.com/AlexIljin/ryu
+| Language         | Author             | Link                                          |
+|------------------|--------------------|-----------------------------------------------|
+| Scala            | Andriy Plokhotnyuk | https://github.com/plokhotnyuk/jsoniter-scala |
+| Rust (C wrapper) | Mara Bos           | https://docs.rs/ryu/0.1.1/ryu/                |
+| Julia            | Jacob Quinn        | https://github.com/quinnj/Ryu.jl              |
+| Factor           | Alexander Iljin    | https://github.com/AlexIljin/ryu              |
+| Go               | Caleb Spare        | https://github.com/cespare/ryu                |
 
 ## Building, Testing, Running
 


### PR DESCRIPTION
Also format the ever-growing list as a table.

Thanks for this algorithm and the implementation! Next I'm planning on changing the Go stdlib itself to use Ryu as its float formatting algorithm.

Two things I noticed while working on this:

- It seemed like one of the optimizations for handling two digits at a time might have been intended to be a loop rather than a single if statement. I brought this up over at #85.
- While comparing performance against the Go stdlib, I copied an optimization that's used there. If a float f represents an integer value and it is within the range where every integer is representable, then we can skip most of the expensive work and construct the decimal representation directly. (See [here](https://github.com/cespare/ryu/blob/ba56a33f39e3bbbfa409095d0f9ae168a595feea/ryu.go#L105-L108) and [here](https://github.com/cespare/ryu/blob/ba56a33f39e3bbbfa409095d0f9ae168a595feea/ryu64.go#L105-L122).) If you're handling random floats then this doesn't happen very often but in real life scenarios I imagine that numbers like 1.0 and 10.0 are overrepresented.

  (This is probably a well-known optimization but I wanted to mention it since that was the main optimization I needed to add to my Ryu implementation in order to reach parity with the Go stdlib on all my test inputs.)