### PR TITLE
Improve uint128 performance by 10.8% and 7.9%

### DIFF
--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -244,9 +244,10 @@ static inline uint32_t append_d_digits(uint32_t olength, uint32_t digits, char* 
     i += 2;
   }
   if (digits >= 10) {
-    result[2] = (char) ('0' + digits % 10);
+    const uint32_t c = digits << 1;
+    result[2] = DIGIT_TABLE[c + 1];
     result[1] = '.';
-    result[0] = (char) ('0' + digits / 10);
+    result[0] = DIGIT_TABLE[c];
   } else {
     result[1] = '.';
     result[0] = (char) ('0' + digits);

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -145,7 +145,7 @@ static inline uint32_t mulShift(const uint64_t m, const uint64_t* const mul, con
     const uint64_t r1 = ((r0 << 32) | (s1low >> 32));
     return mod1e9(r1 >> (j - 160));
   } else if (j < 256) {
-    return mod1e9(s1high << (j - 192));
+    return mod1e9(s1high >> (j - 192));
   }
   return 0;
 }
@@ -192,7 +192,7 @@ static inline uint32_t mulShift2(const uint64_t m, const uint64_t* const mul, co
     const uint64_t r1 = ((r0 << 32) | (s1low >> 32));
     return mod1e9(r1 >> (j - 160));
   } else if (j < 256) {
-    return mod1e9(s1high << (j - 192));
+    return mod1e9(s1high >> (j - 192));
   }
   return 0;
 }

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -20,6 +20,8 @@
 //
 // -DRYU_ONLY_64_BIT_OPS Avoid using uint128_t or 64-bit intrinsics. Slower,
 //     depending on your compiler.
+//
+// -DRYU_AVOID_UINT128 Avoid using uint128_t. Slower, depending on your compiler.
 
 #include "ryu/ryu2.h"
 
@@ -34,12 +36,10 @@
 #include <stdio.h>
 #endif
 
-// ABSL avoids uint128_t on Win32 even if __SIZEOF_INT128__ is defined.
-// Let's do the same for now.
-#if defined(__SIZEOF_INT128__) && !defined(_MSC_VER) && !defined(RYU_ONLY_64_BIT_OPS)
+#if !defined(RYU_ONLY_64_BIT_OPS) && !defined(RYU_AVOID_UINT128) && defined(__SIZEOF_INT128__)
 #define HAS_UINT128
 typedef __uint128_t uint128_t;
-#elif defined(_MSC_VER) && !defined(RYU_ONLY_64_BIT_OPS) && defined(_M_X64)
+#elif !defined(RYU_ONLY_64_BIT_OPS) && defined(_MSC_VER) && defined(_M_X64)
 #define HAS_64_BIT_INTRINSICS
 #endif
 

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -118,6 +118,10 @@ static inline uint32_t mulShift(const uint64_t m, const uint64_t* const mul, con
   const uint64_t s1low = high1 + low2 + c1; // 128
   const uint64_t c2 = s1low < high1;
   const uint64_t s1high = high2 + c2;       // 192
+  // If this assertion fails, c2 has been calculated incorrectly.
+  // This is possible for general multiplications,
+  // but it should be impossible given how mulShift() is called.
+  assert(low2 != 0xFFFFFFFFFFFFFFFFu || c1 != 1);
   if (j < 128) {
 #ifdef RYU_DEBUG
     printf("%d\n", j);

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -86,17 +86,11 @@ static inline uint32_t mulShift(const uint64_t m, const uint64_t* const mul, con
 #endif
   assert(j >= 128);
   assert(j <= 180);
-  if (j == 128) { // j: 128
-    uint128_t s0 = b0 + (b1 << 64); // 0
-    uint32_t c1 = s0 < b0;
-    uint128_t s1 = b2 + (b1 >> 64) + c1; // 128
-    return (uint32_t) uint128_mod1e9(s1);
-  } else { // j: [129, 256)
-    uint128_t s0 = b0 + (b1 << 64); // 0
-    uint32_t c1 = s0 < b0;
-    uint128_t s1 = b2 + (b1 >> 64) + c1; // 128
-    return (uint32_t) uint128_mod1e9(s1 >> (j - 128));
-  }
+  // j: [128, 256)
+  uint128_t s0 = b0 + (b1 << 64); // 0
+  uint32_t c1 = s0 < b0;
+  uint128_t s1 = b2 + (b1 >> 64) + c1; // 128
+  return (uint32_t) uint128_mod1e9(s1 >> (j - 128));
 }
 
 #else // HAS_UINT128

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -395,7 +395,7 @@ int d2fixed_buffered_n(double d, uint32_t precision, char* result) {
 #endif
     for (int i = len - 1; i >= 0; i--) {
       uint32_t j = p10bits - e2;
-      // Temporary: j is usually around 128, and by shifting a bit, we push it above 128, which is
+      // Temporary: j is usually around 128, and by shifting a bit, we push it to 128 or above, which is
       // a slightly faster code path in mulShift. Instead, we can just increase the multipliers.
       uint32_t digits = mulShift(m2 << 8, POW10_SPLIT[POW10_OFFSET[idx] + i], j + 8);
       if (nonzero) {
@@ -441,6 +441,8 @@ int d2fixed_buffered_n(double d, uint32_t precision, char* result) {
         index += fill;
         break;
       }
+      // Temporary: j is usually around 128, and by shifting a bit, we push it to 128 or above, which is
+      // a slightly faster code path in mulShift. Instead, we can just increase the multipliers.
       uint32_t digits = mulShift(m2 << 8, POW10_SPLIT_2[p], j + 8);
 #ifdef RYU_DEBUG
       printf("digits=%u\n", digits);
@@ -602,7 +604,7 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
 #endif
     for (int i = len - 1; i >= 0; i--) {
       uint32_t j = p10bits - e2;
-      // Temporary: j is usually around 128, and by shifting a bit, we push it above 128, which is
+      // Temporary: j is usually around 128, and by shifting a bit, we push it to 128 or above, which is
       // a slightly faster code path in mulShift. Instead, we can just increase the multipliers.
       digits = mulShift(m2 << 8, POW10_SPLIT[POW10_OFFSET[idx] + i], j + 8);
       if (printedDigits != 0) {
@@ -634,6 +636,8 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
     for (int32_t i = MIN_BLOCK_2[idx]; i < 200; i++) {
       int32_t j = ADDITIONAL_BITS_2 + (-e2 - 16 * idx);
       uint32_t p = POW10_OFFSET_2[idx] + i;
+      // Temporary: j is usually around 128, and by shifting a bit, we push it to 128 or above, which is
+      // a slightly faster code path in mulShift. Instead, we can just increase the multipliers.
       digits = (p >= POW10_OFFSET_2[idx + 1]) ? 0 : mulShift(m2 << 8, POW10_SPLIT_2[p], j + 8);
 #ifdef RYU_DEBUG
       printf("exact=%" PRIu64 " * (%" PRIu64 " + %" PRIu64 " << 64) >> %d\n", m2, POW10_SPLIT_2[p][0], POW10_SPLIT_2[p][1], j);

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -385,7 +385,7 @@ int d2fixed_buffered_n(double d, uint32_t precision, char* result) {
   if (ieeeSign) {
     result[index++] = '-';
   }
-  if (e2 >= -53) {
+  if (e2 >= -52) {
     int32_t idx = e2 < 0 ? 0 : indexForExponent(e2);
     int32_t p10bits = pow10BitsForIndex(idx);
     int32_t len = lengthForIndex(idx);

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -130,20 +130,6 @@ static inline uint32_t mulShift(const uint64_t m, const uint64_t* const mul, con
   const uint64_t s1low = high1 + low2 + c1; // 128
   const uint64_t c2 = s1low < high1;
   const uint64_t s1high = high2 + c2;       // 192
-#if 1
-  assert(j >= 128);
-  assert(j <= 181);
-  if (j < 160) {
-    const uint64_t r0 = mod1e9(s1high);
-    const uint64_t r1 = mod1e9((r0 << 32) | (s1low >> 32));
-    const uint64_t r2 = ((r1 << 32) | (s1low & 0xffffffff));
-    return mod1e9(r2 >> (j - 128));
-  } else {
-    const uint64_t r0 = mod1e9(s1high);
-    const uint64_t r1 = ((r0 << 32) | (s1low >> 32));
-    return mod1e9(r1 >> (j - 160));
-  }
-#else // 1
   if (j < 128) {
 #ifdef RYU_DEBUG
     printf("%d\n", j);
@@ -162,7 +148,6 @@ static inline uint32_t mulShift(const uint64_t m, const uint64_t* const mul, con
     return mod1e9(s1high << (j - 192));
   }
   return 0;
-#endif // 1
 }
 
 static inline uint32_t mulShift2(const uint64_t m, const uint64_t* const mul, const int32_t j) {
@@ -179,23 +164,18 @@ static inline uint32_t mulShift2(const uint64_t m, const uint64_t* const mul, co
   const uint64_t s1low = high1 + low2 + c1; // 128
   const uint64_t c2 = s1low < high1;
   const uint64_t s1high = high2 + c2;       // 192
-#if 0
   if (j < 64) {
 #ifdef RYU_DEBUG
     printf("%d\n", j);
 #endif
     assert(false);
   } else if (j < 96) {
-#endif // 0
-    assert(j >= 74);
-    assert(j <= 89);
     const uint64_t r0 = mod1e9(s1high);
     const uint64_t r1 = mod1e9((r0 << 32) | (s1low >> 32));
     const uint64_t r2 = mod1e9((r1 << 32) | (s1low & 0xffffffff));
     const uint64_t r3 = mod1e9((r2 << 32) | (s0high >> 32));
     const uint64_t r4 = ((r3 << 32) | (s0high & 0xffffffff));
     return mod1e9(r4 >> (j - 64));
-#if 0
   } else if (j < 128) {
     const uint64_t r0 = mod1e9(s1high);
     const uint64_t r1 = mod1e9((r0 << 32) | (s1low >> 32));
@@ -215,7 +195,6 @@ static inline uint32_t mulShift2(const uint64_t m, const uint64_t* const mul, co
     return mod1e9(s1high << (j - 192));
   }
   return 0;
-#endif // 0
 }
 
 #endif // HAS_UINT128

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -84,18 +84,18 @@ static inline uint32_t mulShift(const uint64_t m, const uint64_t* const mul, con
   } else if (j < 128) {
     uint64_t b1lo = (uint64_t) b1;
     uint64_t s0 = b1lo + (b0 >> 64); // 64
-    uint128_t c1 = s0 < b1lo;
+    uint32_t c1 = s0 < b1lo;
     uint128_t s1 = b2 + (b1 >> 64) + c1; // 128
     uint128_t r0 = (uint128_mod1e9(s1) << 64) + s0;
     return (uint32_t) uint128_mod1e9(r0 >> (j - 64));
   } else if (j == 128) {
     uint128_t s0 = b0 + (b1 << 64); // 0
-    uint128_t c1 = s0 < b0;
+    uint32_t c1 = s0 < b0;
     uint128_t s1 = b2 + (b1 >> 64) + c1; // 128
     return (uint32_t) uint128_mod1e9(s1);
   } else if (j < 256) {
     uint128_t s0 = b0 + (b1 << 64); // 0
-    uint128_t c1 = s0 < b0;
+    uint32_t c1 = s0 < b0;
     uint128_t s1 = b2 + (b1 >> 64) + c1; // 128
     return (uint32_t) uint128_mod1e9(s1 >> (j - 128));
   }
@@ -114,9 +114,9 @@ static inline uint32_t mulShift(const uint64_t m, const uint64_t* const mul, con
   const uint64_t s0low = low0;              // 0
   (void) s0low; // unused
   const uint64_t s0high = high0 + low1;     // 64
-  const uint64_t c1 = s0high < high0;
+  const uint32_t c1 = s0high < high0;
   const uint64_t s1low = high1 + low2 + c1; // 128
-  const uint64_t c2 = s1low < high1;
+  const uint32_t c2 = s1low < high1;
   const uint64_t s1high = high2 + c2;       // 192
   // If this assertion fails, c2 has been calculated incorrectly.
   // This is possible for general multiplications,

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -180,7 +180,7 @@ static inline uint32_t mulShift2(const uint64_t m, const uint64_t* const mul, co
     const uint64_t r0 = mod1e9(s1high);
     const uint64_t r1 = mod1e9((r0 << 32) | (s1low >> 32));
     const uint64_t r2 = mod1e9((r1 << 32) | (s1low & 0xffffffff));
-    const uint64_t r3 = mod1e9((r2 << 32) | (s0high >> 32));
+    const uint64_t r3 = ((r2 << 32) | (s0high >> 32));
     return mod1e9(r3 >> (j - 96));
   } else if (j < 160) {
     const uint64_t r0 = mod1e9(s1high);

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -102,18 +102,6 @@ static inline uint32_t mulShift(const uint64_t m, const uint64_t* const mul, con
   return 0;
 }
 
-static inline uint32_t mulShift2(const uint64_t m, const uint64_t* const mul, const int32_t j) {
-  const uint128_t b0 = ((uint128_t) m) * mul[0]; // 0
-  const uint128_t b1 = ((uint128_t) m) * mul[1]; // 64
-  if (j <= 64) {
-    assert(false);
-  } else if (j < 192) { // 64 < j < 192
-    uint128_t s = (b0 >> 64) + b1; // 64
-    return (uint32_t) uint128_mod1e9(s >> (j - 64));
-  }
-  return 0;
-}
-
 #else // HAS_UINT128
 
 static inline uint32_t mulShift(const uint64_t m, const uint64_t* const mul, const int32_t j) {
@@ -135,53 +123,6 @@ static inline uint32_t mulShift(const uint64_t m, const uint64_t* const mul, con
     printf("%d\n", j);
 #endif
     assert(false);
-  } else if (j < 160) {
-    const uint64_t r0 = mod1e9(s1high);
-    const uint64_t r1 = mod1e9((r0 << 32) | (s1low >> 32));
-    const uint64_t r2 = ((r1 << 32) | (s1low & 0xffffffff));
-    return mod1e9(r2 >> (j - 128));
-  } else if (j < 192) {
-    const uint64_t r0 = mod1e9(s1high);
-    const uint64_t r1 = ((r0 << 32) | (s1low >> 32));
-    return mod1e9(r1 >> (j - 160));
-  } else if (j < 256) {
-    return mod1e9(s1high >> (j - 192));
-  }
-  return 0;
-}
-
-static inline uint32_t mulShift2(const uint64_t m, const uint64_t* const mul, const int32_t j) {
-  uint64_t high0;                                   // 64
-  const uint64_t low0 = umul128(m, mul[0], &high0); // 0
-  uint64_t high1;                                   // 128
-  const uint64_t low1 = umul128(m, mul[1], &high1); // 64
-  const uint64_t high2 = 0;                         // 192
-  const uint64_t low2 = 0;                          // 128
-  const uint64_t s0low = low0;              // 0
-  (void) s0low; // unused
-  const uint64_t s0high = high0 + low1;     // 64
-  const uint64_t c1 = s0high < high0;
-  const uint64_t s1low = high1 + low2 + c1; // 128
-  const uint64_t c2 = s1low < high1;
-  const uint64_t s1high = high2 + c2;       // 192
-  if (j < 64) {
-#ifdef RYU_DEBUG
-    printf("%d\n", j);
-#endif
-    assert(false);
-  } else if (j < 96) {
-    const uint64_t r0 = mod1e9(s1high);
-    const uint64_t r1 = mod1e9((r0 << 32) | (s1low >> 32));
-    const uint64_t r2 = mod1e9((r1 << 32) | (s1low & 0xffffffff));
-    const uint64_t r3 = mod1e9((r2 << 32) | (s0high >> 32));
-    const uint64_t r4 = ((r3 << 32) | (s0high & 0xffffffff));
-    return mod1e9(r4 >> (j - 64));
-  } else if (j < 128) {
-    const uint64_t r0 = mod1e9(s1high);
-    const uint64_t r1 = mod1e9((r0 << 32) | (s1low >> 32));
-    const uint64_t r2 = mod1e9((r1 << 32) | (s1low & 0xffffffff));
-    const uint64_t r3 = ((r2 << 32) | (s0high >> 32));
-    return mod1e9(r3 >> (j - 96));
   } else if (j < 160) {
     const uint64_t r0 = mod1e9(s1high);
     const uint64_t r1 = mod1e9((r0 << 32) | (s1low >> 32));

--- a/ryu/d2fixed_full_table.h
+++ b/ryu/d2fixed_full_table.h
@@ -17,6 +17,8 @@
 #ifndef RYU_D2FIXED_FULL_TABLE_H
 #define RYU_D2FIXED_FULL_TABLE_H
 
+#include <stdint.h>
+
 #define TABLE_SIZE 64
 
 static uint32_t POW10_OFFSET[TABLE_SIZE] = {


### PR DESCRIPTION
These changes primarily improve mulShift(), activating the uint128 codepath for Clang/LLVM x64 targeting Windows, and improving uint128 perf (hopefully for Linux and Mac too) by 10.8% (for %f) and 7.9% (for %e). There's a small improvement from removing a special case for 0-shifting (previously removed for the non-uint128 codepaths), and a large improvement from implementing a 128-bit magic multiply.

Unlike the 64-bit magic multiplies, where we can just inspect Clang x64 codegen, I had to generate the 128-bit multiplier (`0x89705F4136B4A59731680A88F8953031`, written as two 64-bit constants) and shift value (`29`) myself, with the classic algorithm in Hacker's Delight. (The "add" indicator was 0, resulting in simpler code, happily.) The new helper functions `umul256()` and `umul256_hi()` are modified copies of Ryu's `umul128()` and `umulh()` in d2s_intrinsics.h.

For correctness testing, I've tested over 500 billion unique random doubles with MSVC x64 (non-uint128) and over 568 billion with LLVM uint128, for both %f and %e (compared to MSVC UCRT `sprintf_s()`), with zero differences.

Compiler    | Before  | After
------------|---------|--------
MSVC x86 %f | 361.681 | 361.322
LLVM x86 %f | 352.800 | 352.596
MSVC x64 %f | 159.763 | 159.702
LLVM x64 %f | 116.678 | 116.277
LLVM 128 %f | 112.508 | 101.502

Compiler    | Before  | After
------------|---------|--------
MSVC x86 %e | 114.038 | 113.568
LLVM x86 %e | 104.484 | 104.387
MSVC x64 %e |  56.020 |  55.130
LLVM x64 %e |  40.340 |  40.147
LLVM 128 %e |  40.272 |  37.333

Individual commits:

---

Allow Clang/LLVM to use uint128 on Windows.

It's somewhat faster than the intrinsics codepath.

Support for uint128 on Windows is definitely incomplete (attempting to use division or modulo triggers linker errors due to unimplemented library helpers), but I haven't encountered any problems with the current code.

Add RYU_AVOID_UINT128 as an escape hatch (for perf testing).

---

Revert "Restrict mulShift() and mulShift2() to their actual ranges."

This reverts commit 879d2b76f4f14531d4c9bf6ff610e513976401db.

---

Fix another typo-bug in unused code.

mulShift() and mulShift2() perform a wide multiplication followed by a right shift and a modulo.

The last case, for j within [192, 255], which shifts away everything except for the s1high part of the wide mult, was incorrectly performing a left shift.

This was especially easy to miss because the other cases need `<< 32`.

This didn't affect correctness because the branch isn't being taken (currently `j <= 180` holds), but this should be fixed just in case.

---

Fix yet another typo-bug in unused code.

mulShift2() was incorrectly performing an extra mod1e9() in one case, unlike every other case in mulShift() and mulShift2().

This didn't affect correctness; previously, the broken case wasn't activated due to the possible range of j, and now mulShift2() is completely unused.

(I'm fixing this in case the code is ever needed again.)

---

Remove mulShift2() which is now unused.

---

d2fixed_full_table.h needs to include stdint.h.

---

Improve d2fixed_buffered_n() perf for `e2 == -53`.

We're printing `m2 * 2^e2`, and this branch is for the integer part (to the left of the decimal point).

m2 is the ieeeMantissa with the implicit bit restored (0 for subnormal, 1 for normal), so it's a 53-bit number (at most).

When `e2 == -53`, `m2 * 2^-53` has no integer part, so this branch doesn't need to be taken. (The following code will write a '0' for the integer part, as it already does for more negative exponents.)

This is a strict performance improvement for this exponent, and now this test is consistent with d2exp_buffered_n().

As this affects only one exponent, it's unobservable in the benchmark.

---

Improve mulShift() comments.

After commit c898a78, mulShift() is always called with a shift in the range [128, 180]. I'm updating the comments accordingly.

---

Add an assertion to mulShift().

The code is taking a shortcut when determining whether to carry out of the `high1 + low2 + c1` additions. As far as I can tell, this shortcut is valid given the mantissa range and static tables being used, but there should be an assertion just in case.

---

Store carry bits in uint32_t.

They're either 0 or 1, so at best this can help compilers realize that they don't need to do full 128 + 128 or 64 + 64 additions. At worst, this is a stylistic change to indicate the narrow range.

(This turned out to be unobservable in the benchmark.)

---

Restrict mulShift() to its updated range.

This is a strict performance improvement and reduces codegen size.

---

Don't avoid 0-shifts in uint128 mulShift().

The benchmark indicates that attempting to avoid 0-shifting is counterproductive.

---

Improve uint128 perf with a magic multiply.

---

Use DIGIT_TABLE more often.

This appears to be a very slight performance improvement.