### PR TITLE
Improve perf and carry logic.

### DIFF
--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -166,15 +166,11 @@ static inline uint32_t mulShift(const uint64_t m, const uint64_t* const mul, con
   const uint64_t low2 = umul128(m, mul[2], &high2); // 128
   const uint64_t s0low = low0;              // 0
   (void) s0low; // unused
-  const uint64_t s0high = high0 + low1;     // 64
-  const uint32_t c1 = s0high < high0;
-  const uint64_t s1low = high1 + low2 + c1; // 128
-  const uint32_t c2 = s1low < high1;
+  const uint64_t s0high = low1 + high0;     // 64
+  const uint32_t c1 = s0high < low1;
+  const uint64_t s1low = low2 + high1 + c1; // 128
+  const uint32_t c2 = s1low < low2; // high1 + c1 can't overflow, so compare against low2
   const uint64_t s1high = high2 + c2;       // 192
-  // If this assertion fails, c2 has been calculated incorrectly.
-  // This is possible for general multiplications,
-  // but it should be impossible given how mulShift() is called.
-  assert(low2 != 0xFFFFFFFFFFFFFFFFu || c1 != 1);
 #ifdef RYU_DEBUG
   if (j < 128 || j > 180) {
     printf("%d\n", j);

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -76,7 +76,7 @@ static inline uint128_t umul256(const uint128_t a, const uint64_t bHi, const uin
   const uint64_t mid2Hi = (uint64_t)(mid2 >> 64);
 
   const uint128_t pHi = b11 + mid1Hi + mid2Hi;
-  const uint128_t pLo = ((uint128_t)mid2Lo << 64) + b00Lo;
+  const uint128_t pLo = ((uint128_t)mid2Lo << 64) | b00Lo;
 
   *productHi = pHi;
   return pLo;

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -118,9 +118,8 @@ static inline uint32_t mulShift(const uint64_t m, const uint64_t* const mul, con
   assert(j >= 128);
   assert(j <= 180);
   // j: [128, 256)
-  uint128_t s0 = b0 + (b1 << 64); // 0
-  uint32_t c1 = s0 < b0;
-  uint128_t s1 = b2 + (b1 >> 64) + c1; // 128
+  const uint128_t mid = b1 + (uint64_t) (b0 >> 64); // 64
+  const uint128_t s1 = b2 + (uint64_t) (mid >> 64); // 128
   return uint128_mod1e9(s1 >> (j - 128));
 }
 

--- a/ryu/d2s_intrinsics.h
+++ b/ryu/d2s_intrinsics.h
@@ -70,7 +70,7 @@ static inline uint64_t umul128(const uint64_t a, const uint64_t b, uint64_t* con
   const uint32_t mid2Hi = (uint32_t)(mid2 >> 32);
 
   const uint64_t pHi = b11 + mid1Hi + mid2Hi;
-  const uint64_t pLo = ((uint64_t)mid2Lo << 32) + b00Lo;
+  const uint64_t pLo = ((uint64_t)mid2Lo << 32) | b00Lo;
 
   *productHi = pHi;
   return pLo;


### PR DESCRIPTION
Improve perf and carry logic.

Compiler    | Before  | After
------------|---------|--------
MSVC x86 %f | 357.983 | 356.370
MSVC x86 %e | 107.619 | 105.532
LLVM x86 %f | 352.767 | 353.259
LLVM x86 %e | 104.455 | 104.600

Compiler    | Before  | After   | Speedup
------------|---------|---------|--------
MSVC x64 %f | 159.110 | 118.643 | 34.1%
MSVC x64 %e |  54.288 |  44.169 | 22.9%
LLVM x64 %f | 116.734 |  97.031 | 20.3%
LLVM x64 %e |  40.285 |  36.193 | 11.3%
LLVM 128 %f | 101.752 |  98.859 | 2.9%
LLVM 128 %e |  37.498 |  37.120 | 1.0%

Note that this slightly improves the "headline perf" of the algorithm. Comparing the previous fastest (LLVM uint128) to the new fastest (LLVM x64 intrinsics), %f is 4.9% faster, and %e is 3.6% faster.

Individual commits:

---

Use bitwise OR in umul128() to improve codegen.

When concatenating two 32-bit values, MSVC's x86 codegen is affected by plus versus bitwise OR.

For plus, the codegen is:

```
add eax, DWORD PTR _b00$1$[esp+16]
adc edi, 0
```

That's an add followed by add-with-carry; i.e. the compiler is emitting a general 64 + 32 addition.

For bitwise OR, the codegen is:

```
or  eax, DWORD PTR _b00$1$[esp+16]
```

Bitwise OR is both conceptually simpler and more efficient.

---

Use bitwise OR in umul256() for consistency.

While Clang x64 uint128 codegen is unaffected, we should still change plus to bitwise OR for consistency and conceptual simplicity.

---

Improve x64 intrinsic perf with the magic multiply.

This ports the magic multiply technique in 7209c36 from uint128 to x64 intrinsics. Interestingly, this is slightly faster for Clang/LLVM (at least on Windows), presumably due to weak uint128 optimizations.

Note that when uint128 and x64 intrinsics are unavailable (e.g. x86), the magic multiply is slower than the technique of calling `mod1e9()` repeatedly, which is why that codepath is being retained here.

`umul256_hi128_lo64()` uses `uint64_t` for all math. Therefore, it can't take advantage of the fact that double-width products can absorb two single digits. So, it has explicit carry checks, and names its variables `temp` instead of `mid`.

---

Improve uint128 carrying perf.

`mulShift()` computes three double-width products (b0, b1, b2). It can be restructured to improve codegen by avoiding explicit carrying.

This takes advantage of the fact (used elsewhere) that double-width products can absorb up to two single digits via addition without overflowing. Here, we have b0, b1, and b2 partially overlapping. The low 64 bits of b0 don't get added to anything (and are ignored, because we shift them away later). The high 64 bits of b0 can be added to b1, without overflow due to the double-width product property. This is stored as mid. (The low 64 bits of mid are similarly ignored.) Finally, the high 64 bits of mid can be added to b2, producing the upper 128 bits of the sum.

---

Improve non-uint128 mulShift() carry logic.

In 57b918f, I saw two additions with only one overflow check for carrying, and added an assertion. Now that I understand what the code is doing, the assertion can be removed - but the overflow check actually needs to be changed.

This code is forming and adding double-width products, represented as separate parts (high0 and low0, etc.). This means that we can take advantage of the double-width product property, but we need to be careful to keep track of what each variable represents. We're adding:

```
               high0  low0
+        high1 low1
+ high2  low2
===========================
  s1high s1low s0high s0low
```

Adding low1 to high0 generates s0high. This is taking a double-width product (high1 low1) and adding a single digit (high0), which can't overflow beyond high1. However, it can internally carry within the double-width value (which happens behind the scenes for uint128 + uint64). Here, we need to manually carry with c1, which will be added to high1 (and that cannot overflow).

Then we take high1 + c1 and add low2, generating s1low. Again this is taking a double-width product (high2 low2) and adding a single digit (high1 + c1), which can't overflow beyond high2. Again it can internally carry, so we need a single check.

Here is where the code must be fixed: we're adding two digits, low2 + (high1 + c1), so we need to compare against one of the inputs. Either low2 or (high1 + c1) would be fine, but comparing against high1 is incorrect. (I believe that the code was getting away with it due to the specific ranges of the inputs.) Since low2 is already available, I'm using that.

Note that I have also changed the computation of c1 for stylistic consistency, although there is no correctness issue there. (In a long chain of overlapping additions, we would want to consistently compare against the low part.)

Thanks again to @abolz for explaining the double-width product property to me: https://github.com/ulfjack/ryu/issues/94#issuecomment-458942435