### PR TITLE
Use bitwise OR in umul128() to improve codegen.

### DIFF
--- a/ryu/d2s_intrinsics.h
+++ b/ryu/d2s_intrinsics.h
@@ -69,7 +69,7 @@ static inline uint64_t umul128(const uint64_t a, const uint64_t b, uint64_t* con
   const uint32_t mid2Hi = (uint32_t)(mid2 >> 32);
 
   const uint64_t pHi = b11 + mid1Hi + mid2Hi;
-  const uint64_t pLo = ((uint64_t)mid2Lo << 32) + b00Lo;
+  const uint64_t pLo = ((uint64_t)mid2Lo << 32) | b00Lo;
 
   *productHi = pHi;
   return pLo;


### PR DESCRIPTION
When concatenating two 32-bit values, MSVC's x86 codegen is affected by plus versus bitwise OR.

For plus, the codegen is:

```
add eax, DWORD PTR _b00$1$[esp+16]
adc edi, 0
```

That's an add followed by add-with-carry; i.e. the compiler is emitting a general 64 + 32 addition.

For bitwise OR, the codegen is:

```
or  eax, DWORD PTR _b00$1$[esp+16]
```

Bitwise OR is both conceptually simpler and more efficient.