### PR TITLE
Improve d2exp_buffered_n headline perf.

### DIFF
--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -765,10 +765,17 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
   } else {
     result[index++] = '+';
   }
-  if (exp < 10) {
-    result[index++] = '0';
+
+  if (exp >= 100) {
+    const int32_t c = exp % 10;
+    memcpy(result + index, DIGIT_TABLE + 2 * (exp / 10), 2);
+    result[index + 2] = (char) ('0' + c);
+    index += 3;
+  } else {
+    memcpy(result + index, DIGIT_TABLE + 2 * exp, 2);
+    index += 2;
   }
-  index += append_n_digits(exp, result + index);
+
   return index;
 }
 


### PR DESCRIPTION
Compiler    | Before  | After   | Speedup
------------|---------|---------|--------
MSVC x86 %e | 105.350 | 103.466 | 1.8%
LLVM x86 %e | 104.851 | 102.818 | 2.0%
MSVC x64 %e | 44.677  | 42.745  | 4.5%
LLVM x64 %e | 36.165  | 34.617  | 4.5%
LLVM 128 %e | 36.321  | 35.462  | 2.4%

Previously, `d2exp_buffered_n` used `append_n_digits` to print the exponent. That's a general digit printer, so we ended up doing several expensive things:

* Calling `decimalLength9`, performing several branches before finding that the exponent is always 1, 2, or 3 digits.
* Performing more branches for exponent length. For example, `digits >= 10000` is always false. Then, if `digits >= 100` is true, we divide by 100 and test `digits >= 10`. That handles numbers that were originally 3 or 4 digits, but decimal exponents are never 4 digits.
* We perform unnecessary work for 1-digit exponents (where `printf` style demands a leading zero), printing the '0' and the digit separately.

Instead, we should use the same technique that `to_chars` in d2s.c uses, simplified even further (since we can handle 1-digit and 2-digit exponents identicallly to get that leading zero).

My measurements indicate a significant "headline perf" improvement: 4.5% on x64. I believe that this is because (1) the core algorithm is extremely fast, so exponent overhead is a relatively large expense and (2) the exponent must always be printed.