### PR TITLE
Small improvements (non-performance)

### DIFF
--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -709,18 +709,17 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
     bool trailingZeros;
     // precision was already increased by 1, so we don't need to write + 1 here.
     const int32_t rexp = precision - exp;
+    const int32_t requiredTwos = -e2 - rexp;
     if (rexp < 0) {
-      const int32_t requiredTwos = -e2 - rexp;
       const int32_t requiredFives = -rexp;
       trailingZeros =
           (requiredTwos <= 0 || (requiredTwos < 60 && multipleOfPowerOf2(m2, requiredTwos))) && multipleOfPowerOf5(m2, requiredFives);
     } else {
-      const int32_t requiredTwos = -e2 - rexp;
       trailingZeros = requiredTwos <= 0 || (requiredTwos < 60 && multipleOfPowerOf2(m2, requiredTwos));
     }
     roundUp = trailingZeros ? 2 : 1;
 #ifdef RYU_DEBUG
-//    printf("requiredTwos=%d\n", requiredTwos);
+    printf("requiredTwos=%d\n", requiredTwos);
     printf("trailingZeros=%s\n", trailingZeros ? "true" : "false");
 #endif
   }

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -634,11 +634,11 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
       } else if (digits != 0) {
         availableDigits = decimalLength9(digits);
         exp = i * 9 + availableDigits - 1;
-        if (printedDigits + availableDigits > precision) {
+        if (availableDigits > precision) {
           break;
         }
         index += append_d_digits(availableDigits, digits, result + index, printDecimalPoint);
-        printedDigits += availableDigits;
+        printedDigits = availableDigits;
         availableDigits = 0;
       }
     }
@@ -670,11 +670,11 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
       } else if (digits != 0) {
         availableDigits = decimalLength9(digits);
         exp = -(i + 1) * 9 + availableDigits - 1;
-        if (printedDigits + availableDigits > precision) {
+        if (availableDigits > precision) {
           break;
         }
         index += append_d_digits(availableDigits, digits, result + index, printDecimalPoint);
-        printedDigits += availableDigits;
+        printedDigits = availableDigits;
         availableDigits = 0;
       }
     }

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -673,7 +673,6 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
         if (printedDigits + availableDigits > precision) {
           break;
         }
-        // TODO: This callsite might not need printDecimalPoint logic.
         index += append_d_digits(availableDigits, digits, result + index, printDecimalPoint);
         printedDigits += availableDigits;
         availableDigits = 0;

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -482,7 +482,7 @@ int d2fixed_buffered_n(double d, uint32_t precision, char* result) {
         } else {
           // Is m * 10^(additionalDigits + 1) / 2^(-e2) integer?
           const int32_t requiredTwos = -e2 - precision - 1;
-          const bool trailingZeros = (requiredTwos <= 0) || (requiredTwos < 60 && multipleOfPowerOf2(m2, requiredTwos));
+          const bool trailingZeros = requiredTwos <= 0 || (requiredTwos < 60 && multipleOfPowerOf2(m2, requiredTwos));
           roundUp = trailingZeros ? 2 : 1;
 #ifdef RYU_DEBUG
           printf("requiredTwos=%d\n", requiredTwos);
@@ -522,7 +522,7 @@ int d2fixed_buffered_n(double d, uint32_t precision, char* result) {
           roundUp = 1;
           continue;
         } else {
-          if ((roundUp == 2) && (c % 2 == 0)) {
+          if (roundUp == 2 && c % 2 == 0) {
             break;
           }
           result[roundIndex] = c + 1;
@@ -753,7 +753,7 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
         roundUp = 1;
         continue;
       } else {
-        if ((roundUp == 2) && (c % 2 == 0)) {
+        if (roundUp == 2 && c % 2 == 0) {
           break;
         }
         result[roundIndex] = c + 1;

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -468,9 +468,9 @@ int d2fixed_buffered_n(double d, uint32_t precision, char* result) {
         append_nine_digits(digits, result + index);
         index += 9;
       } else {
-        const int32_t max = precision - 9 * i;
+        const int32_t maximum = precision - 9 * i;
         int32_t lastDigit = 0;
-        for (int32_t k = 0; k < 9 - max; ++k) {
+        for (int32_t k = 0; k < 9 - maximum; ++k) {
           lastDigit = digits % 10;
           digits /= 10;
         }
@@ -489,9 +489,9 @@ int d2fixed_buffered_n(double d, uint32_t precision, char* result) {
           printf("trailingZeros=%s\n", trailingZeros ? "true" : "false");
 #endif
         }
-        if (max > 0) {
-          append_c_digits(max, digits, result + index);
-          index += max;
+        if (maximum > 0) {
+          append_c_digits(maximum, digits, result + index);
+          index += maximum;
         }
         break;
       }
@@ -681,18 +681,18 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
     }
   }
 
-  const uint32_t max = precision - printedDigits;
+  const uint32_t maximum = precision - printedDigits;
 #ifdef RYU_DEBUG
   printf("availableDigits=%d\n", availableDigits);
   printf("digits=%d\n", digits);
-  printf("max=%d\n", max);
+  printf("maximum=%d\n", maximum);
 #endif
   if (availableDigits == 0) {
     digits = 0;
   }
   int32_t lastDigit = 0;
-  if (availableDigits > max) {
-    for (uint32_t k = 0; k < availableDigits - max; ++k) {
+  if (availableDigits > maximum) {
+    for (uint32_t k = 0; k < availableDigits - maximum; ++k) {
       lastDigit = digits % 10;
       digits /= 10;
     }
@@ -726,13 +726,13 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
   }
   if (printedDigits != 0) {
     if (digits == 0) {
-      memset(result + index, '0', max);
+      memset(result + index, '0', maximum);
     } else {
-      append_c_digits(max, digits, result + index);
+      append_c_digits(maximum, digits, result + index);
     }
-    index += max;
+    index += maximum;
   } else {
-    index += append_d_digits(max, digits, result + index, printDecimalPoint);
+    index += append_d_digits(maximum, digits, result + index, printDecimalPoint);
   }
 #ifdef RYU_DEBUG
   printf("roundUp=%d\n", roundUp);

--- a/ryu/tests/d2fixed_test.cc
+++ b/ryu/tests/d2fixed_test.cc
@@ -36022,3 +36022,13 @@ TEST(D2expTest, AllBinaryExponents) {
     EXPECT_STREQ(d2exp(tc.value, tc.exp_precision), tc.exp_string);
   }
 }
+
+TEST(D2expTest, PrintDecimalPoint) {
+  // These values exercise each codepath.
+  EXPECT_STREQ(d2exp(1e+54, 0), "1e+54"  );
+  EXPECT_STREQ(d2exp(1e+54, 1), "1.0e+54");
+  EXPECT_STREQ(d2exp(1e-63, 0), "1e-63"  );
+  EXPECT_STREQ(d2exp(1e-63, 1), "1.0e-63");
+  EXPECT_STREQ(d2exp(1e+83, 0), "1e+83"  );
+  EXPECT_STREQ(d2exp(1e+83, 1), "1.0e+83");
+}

--- a/ryu/tests/d2fixed_test.cc
+++ b/ryu/tests/d2fixed_test.cc
@@ -35829,6 +35829,10 @@ TEST(D2fixedTest, AllBinaryExponents) {
   }
 }
 
+TEST(D2fixedTest, Regression) {
+  EXPECT_STREQ(d2fixed(7.018232e-82, 6), "0.000000");
+}
+
 TEST(D2expTest, Basic) {
   EXPECT_STREQ(d2exp(ieeeParts2Double(false, 1234, 99999), 62),
     "3.29100911471548643542566484557342614975886952410844652587974656e+63");
@@ -36017,8 +36021,4 @@ TEST(D2expTest, AllBinaryExponents) {
   for (const auto& tc : all_binary_exponents) {
     EXPECT_STREQ(d2exp(tc.value, tc.exp_precision), tc.exp_string);
   }
-}
-
-TEST(D2expTest, Regression) {
-  EXPECT_STREQ(d2fixed(7.018232e-82, 6), "0.000000");
 }


### PR DESCRIPTION
Individual commits:

---

Rename `max` to `maximum`.

This is an MSVC-specific thing; we have headers that macroize `max` and `__max`, so I want to avoid this particular identifier (even though the function-like macros aren't technically causing problems here).

`maximum` avoids this minor headache without affecting code clarity.

---

Avoid requiredTwos duplication.

This was being computed identically on both sides of a branch (without any variables being modified in between), so it can be lifted up, and a RYU_DEBUG line can be uncommented. The scope ends immediately afterwards.

---

Remove unnecessary parens.

Comparisons have higher precedence than logical operators and this is visually unsurprising. This removal makes it easier to see necessary parens that are overriding precedence rules, clarifying confusing rules, or squashing compiler warnings.

---

Move Regression to the D2fixedTest group.

This is testing `d2fixed()`, so it was in the wrong place.

---

All printDecimalPoint logic is necessary; test it.

When I implemented the printDecimalPoint fix in 2e05ace, I was unsure whether all of the `append_d_digits()` callsites needed it. Now I've found concrete inputs that exercise `true` and `false` for each callsite, so I'm removing the TODO comment and adding tests.

---

Simplify printedDigits usage.

Within this control flow:

```
if (printedDigits != 0) {
  // ...
} else if (digits != 0) {
```

we're guaranteed `printedDigits == 0`, so the following code can be slightly simplified.

---

Refactor for downstream bounds checking.

While implementing C++17 charconv, I need to intrusively modify `d2fixed_buffered_n()` and `d2exp_buffered_n()` to perform bounds checking (and return `std::to_chars_result`). I haven't yet figured out an elegant way to contribute such changes (including similar changes to `d2s_buffered_n()` etc.) upstream without affecting performance, but this hasn't been a big headache for me. The changes are fairly narrow (focused around writes to `result`) so they don't touch the core algorithm and I can easily merge upstream changes.

However, d2fixed.c's helper functions are a slight wrench in my plans, so I would like to suggest changes to upstream that will make downstream bounds checking easier.

The issue is when `append_n_digits()` and `append_d_digits()` decide how much output to write. `append_n_digits()` discovers and returns `olength`, so how much output will be written isn't known ahead of time. `append_d_digits()` is told `olength` and `printDecimalPoint`, and writes a variable amount of output.

Bounds checking will be easier to apply if `d2fixed_buffered_n()` and `d2exp_buffered_n()` know how much output will be written before calling these helpers, so the helpers can assume they have sufficient space and return `void`. The necessary changes are reasonably small. While they involve a bit of code duplication for `printDecimalPoint`, this makes the hidden control flow clearer, which is probably an advantage.