### PR TITLE
Fix sign warnings.

### DIFF
--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -278,7 +278,7 @@ static inline void append_c_digits(const uint32_t count, uint32_t digits, char* 
     memcpy(result + count - i - 2, DIGIT_TABLE + c, 2);
   }
   if (i < count) {
-    const char c = '0' + (digits % 10);
+    const char c = (char) ('0' + (digits % 10));
     result[count - i - 1] = c;
   }
 }

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -391,7 +391,7 @@ int d2fixed_buffered_n(double d, uint32_t precision, char* result) {
     result[index++] = '-';
   }
   if (e2 >= -52) {
-    const int32_t idx = e2 < 0 ? 0 : indexForExponent((uint32_t) e2);
+    const uint32_t idx = e2 < 0 ? 0 : indexForExponent((uint32_t) e2);
     const int32_t p10bits = pow10BitsForIndex(idx);
     const int32_t len = lengthForIndex(idx);
 #ifdef RYU_DEBUG
@@ -605,7 +605,7 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
   uint32_t availableDigits = 0;
   int32_t exp = 0;
   if (e2 >= -52) {
-    const int32_t idx = e2 < 0 ? 0 : indexForExponent((uint32_t) e2);
+    const uint32_t idx = e2 < 0 ? 0 : indexForExponent((uint32_t) e2);
     const int32_t p10bits = pow10BitsForIndex(idx);
     const int32_t len = lengthForIndex(idx);
 #ifdef RYU_DEBUG

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -463,7 +463,7 @@ int d2fixed_buffered_n(double d, uint32_t precision, char* result) {
         index += 9;
       } else {
         const uint32_t maximum = precision - 9 * i;
-        int32_t lastDigit = 0;
+        uint32_t lastDigit = 0;
         for (uint32_t k = 0; k < 9 - maximum; ++k) {
           lastDigit = digits % 10;
           digits /= 10;
@@ -693,7 +693,7 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
   if (availableDigits == 0) {
     digits = 0;
   }
-  int32_t lastDigit = 0;
+  uint32_t lastDigit = 0;
   if (availableDigits > maximum) {
     for (uint32_t k = 0; k < availableDigits - maximum; ++k) {
       lastDigit = digits % 10;

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -391,7 +391,7 @@ int d2fixed_buffered_n(double d, uint32_t precision, char* result) {
     result[index++] = '-';
   }
   if (e2 >= -52) {
-    const int32_t idx = e2 < 0 ? 0 : indexForExponent(e2);
+    const int32_t idx = e2 < 0 ? 0 : indexForExponent((uint32_t) e2);
     const int32_t p10bits = pow10BitsForIndex(idx);
     const int32_t len = lengthForIndex(idx);
 #ifdef RYU_DEBUG
@@ -605,7 +605,7 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
   uint32_t availableDigits = 0;
   int32_t exp = 0;
   if (e2 >= -52) {
-    const int32_t idx = e2 < 0 ? 0 : indexForExponent(e2);
+    const int32_t idx = e2 < 0 ? 0 : indexForExponent((uint32_t) e2);
     const int32_t p10bits = pow10BitsForIndex(idx);
     const int32_t len = lengthForIndex(idx);
 #ifdef RYU_DEBUG

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -201,7 +201,7 @@ static inline uint32_t mulShift_mod1e9(const uint64_t m, const uint64_t* const m
 
 static inline void append_n_digits(const uint32_t olength, uint32_t digits, char* const result) {
 #ifdef RYU_DEBUG
-  printf("DIGITS=%d\n", digits);
+  printf("DIGITS=%u\n", digits);
 #endif
 
   uint32_t i = 0;
@@ -234,7 +234,7 @@ static inline void append_n_digits(const uint32_t olength, uint32_t digits, char
 
 static inline void append_d_digits(const uint32_t olength, uint32_t digits, char* const result) {
 #ifdef RYU_DEBUG
-  printf("DIGITS=%d\n", digits);
+  printf("DIGITS=%u\n", digits);
 #endif
 
   uint32_t i = 0;
@@ -270,7 +270,7 @@ static inline void append_d_digits(const uint32_t olength, uint32_t digits, char
 
 static inline void append_c_digits(const uint32_t count, uint32_t digits, char* const result) {
 #ifdef RYU_DEBUG
-  printf("DIGITS=%d\n", digits);
+  printf("DIGITS=%u\n", digits);
 #endif
   uint32_t i = 0;
   for (; i < count - 1; i += 2) {
@@ -286,7 +286,7 @@ static inline void append_c_digits(const uint32_t count, uint32_t digits, char* 
 
 static inline void append_nine_digits(uint32_t digits, char* const result) {
 #ifdef RYU_DEBUG
-  printf("DIGITS=%d\n", digits);
+  printf("DIGITS=%u\n", digits);
 #endif
   if (digits == 0) {
     memset(result, '0', 9);
@@ -396,7 +396,7 @@ int d2fixed_buffered_n(double d, uint32_t precision, char* result) {
     const uint32_t p10bits = pow10BitsForIndex(idx);
     const int32_t len = (int32_t) lengthForIndex(idx);
 #ifdef RYU_DEBUG
-    printf("idx=%d\n", idx);
+    printf("idx=%u\n", idx);
     printf("len=%d\n", len);
 #endif
     for (int32_t i = len - 1; i >= 0; --i) {
@@ -470,7 +470,7 @@ int d2fixed_buffered_n(double d, uint32_t precision, char* result) {
           digits /= 10;
         }
 #ifdef RYU_DEBUG
-        printf("lastDigit=%d\n", lastDigit);
+        printf("lastDigit=%u\n", lastDigit);
 #endif
         if (lastDigit != 5) {
           roundUp = lastDigit > 5;
@@ -611,7 +611,7 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
     const uint32_t p10bits = pow10BitsForIndex(idx);
     const int32_t len = (int32_t) lengthForIndex(idx);
 #ifdef RYU_DEBUG
-    printf("idx=%d\n", idx);
+    printf("idx=%u\n", idx);
     printf("len=%d\n", len);
 #endif
     for (int32_t i = len - 1; i >= 0; --i) {
@@ -658,7 +658,7 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
       digits = (p >= POW10_OFFSET_2[idx + 1]) ? 0 : mulShift_mod1e9(m2 << 8, POW10_SPLIT_2[p], j + 8);
 #ifdef RYU_DEBUG
       printf("exact=%" PRIu64 " * (%" PRIu64 " + %" PRIu64 " << 64) >> %d\n", m2, POW10_SPLIT_2[p][0], POW10_SPLIT_2[p][1], j);
-      printf("digits=%d\n", digits);
+      printf("digits=%u\n", digits);
 #endif
       if (printedDigits != 0) {
         if (printedDigits + 9 > precision) {
@@ -688,9 +688,9 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
 
   const uint32_t maximum = precision - printedDigits;
 #ifdef RYU_DEBUG
-  printf("availableDigits=%d\n", availableDigits);
-  printf("digits=%d\n", digits);
-  printf("maximum=%d\n", maximum);
+  printf("availableDigits=%u\n", availableDigits);
+  printf("digits=%u\n", digits);
+  printf("maximum=%u\n", maximum);
 #endif
   if (availableDigits == 0) {
     digits = 0;
@@ -703,7 +703,7 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
     }
   }
 #ifdef RYU_DEBUG
-  printf("lastDigit=%d\n", lastDigit);
+  printf("lastDigit=%u\n", lastDigit);
 #endif
   // 0 = don't round up; 1 = round up unconditionally; 2 = round up if odd.
   int roundUp = 0;

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -402,7 +402,7 @@ int d2fixed_buffered_n(double d, uint32_t precision, char* result) {
       const uint32_t j = p10bits - e2;
       // Temporary: j is usually around 128, and by shifting a bit, we push it to 128 or above, which is
       // a slightly faster code path in mulShift_mod1e9. Instead, we can just increase the multipliers.
-      const uint32_t digits = mulShift_mod1e9(m2 << 8, POW10_SPLIT[POW10_OFFSET[idx] + i], j + 8);
+      const uint32_t digits = mulShift_mod1e9(m2 << 8, POW10_SPLIT[POW10_OFFSET[idx] + i], (int32_t) (j + 8));
       if (nonzero) {
         append_nine_digits(digits, result + index);
         index += 9;
@@ -616,7 +616,7 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
       const uint32_t j = p10bits - e2;
       // Temporary: j is usually around 128, and by shifting a bit, we push it to 128 or above, which is
       // a slightly faster code path in mulShift_mod1e9. Instead, we can just increase the multipliers.
-      digits = mulShift_mod1e9(m2 << 8, POW10_SPLIT[POW10_OFFSET[idx] + i], j + 8);
+      digits = mulShift_mod1e9(m2 << 8, POW10_SPLIT[POW10_OFFSET[idx] + i], (int32_t) (j + 8));
       if (printedDigits != 0) {
         if (printedDigits + 9 > precision) {
           availableDigits = 9;

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -393,12 +393,12 @@ int d2fixed_buffered_n(double d, uint32_t precision, char* result) {
   if (e2 >= -52) {
     const uint32_t idx = e2 < 0 ? 0 : indexForExponent((uint32_t) e2);
     const uint32_t p10bits = pow10BitsForIndex(idx);
-    const int32_t len = lengthForIndex(idx);
+    const int32_t len = (int32_t) lengthForIndex(idx);
 #ifdef RYU_DEBUG
     printf("idx=%d\n", idx);
     printf("len=%d\n", len);
 #endif
-    for (int i = len - 1; i >= 0; --i) {
+    for (int32_t i = len - 1; i >= 0; --i) {
       const uint32_t j = p10bits - e2;
       // Temporary: j is usually around 128, and by shifting a bit, we push it to 128 or above, which is
       // a slightly faster code path in mulShift_mod1e9. Instead, we can just increase the multipliers.
@@ -607,12 +607,12 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
   if (e2 >= -52) {
     const uint32_t idx = e2 < 0 ? 0 : indexForExponent((uint32_t) e2);
     const uint32_t p10bits = pow10BitsForIndex(idx);
-    const int32_t len = lengthForIndex(idx);
+    const int32_t len = (int32_t) lengthForIndex(idx);
 #ifdef RYU_DEBUG
     printf("idx=%d\n", idx);
     printf("len=%d\n", len);
 #endif
-    for (int i = len - 1; i >= 0; --i) {
+    for (int32_t i = len - 1; i >= 0; --i) {
       const uint32_t j = p10bits - e2;
       // Temporary: j is usually around 128, and by shifting a bit, we push it to 128 or above, which is
       // a slightly faster code path in mulShift_mod1e9. Instead, we can just increase the multipliers.

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -127,7 +127,8 @@ static inline uint32_t mulShift_mod1e9(const uint64_t m, const uint64_t* const m
 
 #if defined(HAS_64_BIT_INTRINSICS)
 // Returns the low 64 bits of the high 128 bits of the 256-bit product of a and b.
-static inline uint64_t umul256_hi128_lo64(const uint64_t aHi, const uint64_t aLo, const uint64_t bHi, const uint64_t bLo) {
+static inline uint64_t umul256_hi128_lo64(
+  const uint64_t aHi, const uint64_t aLo, const uint64_t bHi, const uint64_t bLo) {
   uint64_t b00Hi;
   const uint64_t b00Lo = umul128(aLo, bLo, &b00Hi);
   uint64_t b01Hi;

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -710,15 +710,14 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
     roundUp = lastDigit > 5;
   } else {
     // Is m * 2^e2 * 10^(precision + 1 - exp) integer?
-    bool trailingZeros;
     // precision was already increased by 1, so we don't need to write + 1 here.
     const int32_t rexp = (int32_t) precision - exp;
     const int32_t requiredTwos = -e2 - rexp;
+    bool trailingZeros = requiredTwos <= 0
+      || (requiredTwos < 60 && multipleOfPowerOf2(m2, (uint32_t) requiredTwos));
     if (rexp < 0) {
       const int32_t requiredFives = -rexp;
-      trailingZeros = (requiredTwos <= 0 || (requiredTwos < 60 && multipleOfPowerOf2(m2, (uint32_t) requiredTwos))) && multipleOfPowerOf5(m2, (uint32_t) requiredFives);
-    } else {
-      trailingZeros = requiredTwos <= 0 || (requiredTwos < 60 && multipleOfPowerOf2(m2, (uint32_t) requiredTwos));
+      trailingZeros = trailingZeros && multipleOfPowerOf5(m2, (uint32_t) requiredFives);
     }
     roundUp = trailingZeros ? 2 : 1;
 #ifdef RYU_DEBUG

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -712,12 +712,11 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
     // Is m * 2^e2 * 10^(precision + 1 - exp) integer?
     bool trailingZeros;
     // precision was already increased by 1, so we don't need to write + 1 here.
-    const int32_t rexp = precision - exp;
+    const int32_t rexp = (int32_t) precision - exp;
     const int32_t requiredTwos = -e2 - rexp;
     if (rexp < 0) {
       const int32_t requiredFives = -rexp;
-      trailingZeros =
-          (requiredTwos <= 0 || (requiredTwos < 60 && multipleOfPowerOf2(m2, requiredTwos))) && multipleOfPowerOf5(m2, requiredFives);
+      trailingZeros = (requiredTwos <= 0 || (requiredTwos < 60 && multipleOfPowerOf2(m2, requiredTwos))) && multipleOfPowerOf5(m2, (uint32_t) requiredFives);
     } else {
       trailingZeros = requiredTwos <= 0 || (requiredTwos < 60 && multipleOfPowerOf2(m2, requiredTwos));
     }

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -447,7 +447,7 @@ int d2fixed_buffered_n(double d, uint32_t precision, char* result) {
       if (p >= POW10_OFFSET_2[idx + 1]) {
         // If the remaining digits are all 0, then we might as well use memset.
         // No rounding required in this case.
-        const int32_t fill = precision - 9 * i;
+        const uint32_t fill = precision - 9 * i;
         memset(result + index, '0', fill);
         index += fill;
         break;

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -462,9 +462,9 @@ int d2fixed_buffered_n(double d, uint32_t precision, char* result) {
         append_nine_digits(digits, result + index);
         index += 9;
       } else {
-        const int32_t maximum = precision - 9 * i;
+        const uint32_t maximum = precision - 9 * i;
         int32_t lastDigit = 0;
-        for (int32_t k = 0; k < 9 - maximum; ++k) {
+        for (uint32_t k = 0; k < 9 - maximum; ++k) {
           lastDigit = digits % 10;
           digits /= 10;
         }

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -651,7 +651,7 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
 #endif
     for (int32_t i = MIN_BLOCK_2[idx]; i < 200; ++i) {
       const int32_t j = ADDITIONAL_BITS_2 + (-e2 - 16 * idx);
-      const uint32_t p = POW10_OFFSET_2[idx] + i - MIN_BLOCK_2[idx];
+      const uint32_t p = POW10_OFFSET_2[idx] + (uint32_t) i - MIN_BLOCK_2[idx];
       // Temporary: j is usually around 128, and by shifting a bit, we push it to 128 or above, which is
       // a slightly faster code path in mulShift_mod1e9. Instead, we can just increase the multipliers.
       digits = (p >= POW10_OFFSET_2[idx + 1]) ? 0 : mulShift_mod1e9(m2 << 8, POW10_SPLIT_2[p], j + 8);

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -628,7 +628,7 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
         printedDigits += 9;
       } else if (digits != 0) {
         availableDigits = decimalLength9(digits);
-        exp = i * 9 + availableDigits - 1;
+        exp = i * 9 + (int32_t) availableDigits - 1;
         if (availableDigits > precision) {
           break;
         }
@@ -669,7 +669,7 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
         printedDigits += 9;
       } else if (digits != 0) {
         availableDigits = decimalLength9(digits);
-        exp = -(i + 1) * 9 + availableDigits - 1;
+        exp = -(i + 1) * 9 + (int32_t) availableDigits - 1;
         if (availableDigits > precision) {
           break;
         }

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -392,7 +392,7 @@ int d2fixed_buffered_n(double d, uint32_t precision, char* result) {
   }
   if (e2 >= -52) {
     const uint32_t idx = e2 < 0 ? 0 : indexForExponent((uint32_t) e2);
-    const int32_t p10bits = pow10BitsForIndex(idx);
+    const uint32_t p10bits = pow10BitsForIndex(idx);
     const int32_t len = lengthForIndex(idx);
 #ifdef RYU_DEBUG
     printf("idx=%d\n", idx);
@@ -606,7 +606,7 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
   int32_t exp = 0;
   if (e2 >= -52) {
     const uint32_t idx = e2 < 0 ? 0 : indexForExponent((uint32_t) e2);
-    const int32_t p10bits = pow10BitsForIndex(idx);
+    const uint32_t p10bits = pow10BitsForIndex(idx);
     const int32_t len = lengthForIndex(idx);
 #ifdef RYU_DEBUG
     printf("idx=%d\n", idx);

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -475,8 +475,9 @@ int d2fixed_buffered_n(double d, uint32_t precision, char* result) {
           roundUp = lastDigit > 5;
         } else {
           // Is m * 10^(additionalDigits + 1) / 2^(-e2) integer?
-          const int32_t requiredTwos = -e2 - precision - 1;
-          const bool trailingZeros = requiredTwos <= 0 || (requiredTwos < 60 && multipleOfPowerOf2(m2, requiredTwos));
+          const int32_t requiredTwos = -e2 - (int32_t) precision - 1;
+          const bool trailingZeros = requiredTwos <= 0
+            || (requiredTwos < 60 && multipleOfPowerOf2(m2, (uint32_t) requiredTwos));
           roundUp = trailingZeros ? 2 : 1;
 #ifdef RYU_DEBUG
           printf("requiredTwos=%d\n", requiredTwos);

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -716,9 +716,9 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
     const int32_t requiredTwos = -e2 - rexp;
     if (rexp < 0) {
       const int32_t requiredFives = -rexp;
-      trailingZeros = (requiredTwos <= 0 || (requiredTwos < 60 && multipleOfPowerOf2(m2, requiredTwos))) && multipleOfPowerOf5(m2, (uint32_t) requiredFives);
+      trailingZeros = (requiredTwos <= 0 || (requiredTwos < 60 && multipleOfPowerOf2(m2, (uint32_t) requiredTwos))) && multipleOfPowerOf5(m2, (uint32_t) requiredFives);
     } else {
-      trailingZeros = requiredTwos <= 0 || (requiredTwos < 60 && multipleOfPowerOf2(m2, requiredTwos));
+      trailingZeros = requiredTwos <= 0 || (requiredTwos < 60 && multipleOfPowerOf2(m2, (uint32_t) requiredTwos));
     }
     roundUp = trailingZeros ? 2 : 1;
 #ifdef RYU_DEBUG

--- a/ryu/d2fixed.c
+++ b/ryu/d2fixed.c
@@ -377,7 +377,7 @@ int d2fixed_buffered_n(double d, uint32_t precision, char* result) {
     e2 = 1 - DOUBLE_BIAS - DOUBLE_MANTISSA_BITS;
     m2 = ieeeMantissa;
   } else {
-    e2 = ieeeExponent - DOUBLE_BIAS - DOUBLE_MANTISSA_BITS;
+    e2 = (int32_t) ieeeExponent - DOUBLE_BIAS - DOUBLE_MANTISSA_BITS;
     m2 = (1ull << DOUBLE_MANTISSA_BITS) | ieeeMantissa;
   }
 
@@ -586,7 +586,7 @@ int d2exp_buffered_n(double d, uint32_t precision, char* result) {
     e2 = 1 - DOUBLE_BIAS - DOUBLE_MANTISSA_BITS;
     m2 = ieeeMantissa;
   } else {
-    e2 = ieeeExponent - DOUBLE_BIAS - DOUBLE_MANTISSA_BITS;
+    e2 = (int32_t) ieeeExponent - DOUBLE_BIAS - DOUBLE_MANTISSA_BITS;
     m2 = (1ull << DOUBLE_MANTISSA_BITS) | ieeeMantissa;
   }
 

--- a/ryu/tests/d2fixed_test.cc
+++ b/ryu/tests/d2fixed_test.cc
@@ -16,15 +16,16 @@
 // KIND, either express or implied.
 
 #include <math.h>
+#include <stdint.h>
 
 #include "ryu/ryu2.h"
 #include "third_party/gtest/gtest.h"
 
 struct test_case {
   double value;
-  int fixed_precision;
+  uint32_t fixed_precision;
   const char* fixed_string;
-  int exp_precision;
+  uint32_t exp_precision;
   const char* exp_string;
 };
 


### PR DESCRIPTION
These are sign warnings of the form "warning C4365: '=': conversion from 'uint32_t' to 'int32_t', signed/unsigned mismatch". They're relatively noisy, but they can find unintentional value-modifying conversions (e.g. from negative signed to huge unsigned), so we test our STL with them. I found zero real issues while cleaning this up; the fine-grained commits and detailed analysis were for avoiding unintentional damage. Individual commits:

---

Fix sign warnings in d2fixed_test.cc.

d2fixed() and d2exp() take `uint32_t precision`, so `test_case` should store that type.

---

Fix sign/truncation warnings for char.

As usual, after doing math, we need to cast back to char.

---

Fix sign warnings for e2.

Like d2s.c, normal ieeeExponent values are within [1, 2046], so we should have a value-preserving cast from uint32_t to int32_t before subtracting to produce possibly negative values.

---

Fix sign warnings for indexForExponent().

e2 is int32_t but indexForExponent() takes uint32_t. In this branch of the conditional operator, we know that `e2 >= 0`, so we can use a value-preserving cast.

---

Fix sign warnings for idx.

indexForExponent() returns uint32_t. This idx is used in only three expressions: pow10BitsForIndex() and lengthForIndex() take uint32_t, and `POW10_OFFSET[idx]` doesn't care. Therefore, we can safely change its type to uint32_t.

---

Fix sign warnings for p10bits.

pow10BitsForIndex() returns uint32_t, and the only use of p10bits is to initialize `const uint32_t j = p10bits - e2;`. Therefore, we can safely change its type to uint32_t.

---

Fix sign warnings for len.

lengthForIndex() returns uint32_t (never an enormous value). The only use of len is `for (int i = len - 1; i >= 0; --i)` which really wants a signed value due to "countdown to 0" behavior. Therefore, we should cast the return value of lengthForIndex() to int32_t. Additionally for consistency, I'm changing the type of i from int to int32_t.

---

Fix sign warnings for mulShift_mod1e9().

mulShift_mod1e9() takes `const int32_t j`. This is within [128, 180], so when we have uint32_t, we can use a value-preserving cast to int32_t.

---

Fix sign warnings for fill.

Both precision and i are uint32_t, and memset()'s third parameter is size_t, so we can safely change the type of fill to uint32_t. The only other use is `index += fill;`, which doesn't trigger sign warnings despite index being int.

---

Fix sign warnings for maximum.

Here, both precision and i are uint32_t, but we should determine whether `9 * i` can be greater than precision. We're inside a `for (; i < blocks; ++i)` loop, and within a `if (i < blocks - 1) { ... } else {` branch. Therefore, `i == blocks - 1`.

`blocks == precision / 9 + 1`, so `i == precision / 9 + 1 - 1`, so `i == precision / 9`.

Therefore, `precision - 9 * i == precision % 9`.

Therefore, we can safely change the type of maximum to uint32_t. We also need to change the type of k. Because maximum is [0, 8], `9 - maximum` is [1, 9], so this change is also safe.

This helps below, as append_c_digits() takes `const uint32_t count` as its first parameter. As before, `index += maximum;` doesn't trigger sign warnings with MSVC.

---

Fix sign warnings for lastDigit.

`lastDigit` stores `digits % 10`, given `uint32_t digits`. Later, it appears in the comparisons `lastDigit != 5` and `lastDigit > 5`. Changing its type to uint32_t is therefore safe.

---

Fix sign warnings for requiredTwos.

requiredTwos can be negative, so we need to cast `uint32_t precision` to int32_t before performing arithmetic.

Later, given `requiredTwos > 0`, we need a value-preserving cast to uint32_t, in order to match multipleOfPowerOf2()'s second parameter.

---

Fix sign warnings for availableDigits.

Here, `uint32_t availableDigits` is [1, 9] returned from decimalLength9(). We need value-preserving casts before performing arithmetic for `int32_t exp`.

---

Fix sign warnings.

Within `for (int32_t i = MIN_BLOCK_2[idx]; i < 200; ++i)`, where `MIN_BLOCK_2` is a table of uint8_t, casting `i` to uint32_t is value-preserving.

---

Fix sign warnings for rexp.

rexp can be negative, so we need to cast `uint32_t precision` to int32_t before performing arithmetic.

Later, after testing `rexp < 0`, we have `const int32_t requiredFives = -rexp;`. Therefore, `requiredFives > 0`, so we could cast and store uint32_t to match multipleOfPowerOf5()'s second parameter. However, that would be inconsistent with `int32_t requiredTwos`, so instead I'm introducing a value-preserving cast when calling multipleOfPowerOf5().

---

Fix sign warnings for requiredTwos.

After branching, we know that `requiredTwos > 0`, so we need value-preserving casts to match multipleOfPowerOf2()'s second parameter.

---

Deduplicate trailingZeros logic.

This makes it clearer that negative and non-negative `rexp` behave identically except for an additional criterion in the negative case.

---

Wrap a long line.

---

Fix GCC -Wformat-signedness warnings in RYU_DEBUG.