### PR TITLE
Add meson build setup for C libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bazel-*
+build*
 /.eclipse-bin/
 /.project
 .vscode/

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,8 @@
+# Build Ryu library
+
+project('ryu', [ 'c', 'cpp' ] )
+
+base_include_dir = include_directories('.')
+
+subdir('third_party/gtest')
+subdir('ryu')

--- a/ryu/meson.build
+++ b/ryu/meson.build
@@ -1,0 +1,30 @@
+# The Ryu library
+
+srcs = [
+    'f2s.c',
+    'd2s.c',
+]
+
+install_headers(files('ryu.h'))
+
+# Plain Ryu (f2s, d2s)
+libryu = library('ryu', srcs,
+    include_directories : base_include_dir,
+    install : true)
+
+# Ryu printf (d2fixed)
+libryu_printf = library('ryu_printf', 'd2fixed.c',
+    include_directories : base_include_dir,
+    install : true)
+
+# 128bit helpers
+libgen128 = library('generic_128', 'generic_128.c',
+    include_directories : base_include_dir,
+    install : false)
+
+subdir('tests')
+
+# Some simple example snippet
+example = executable('example', 'example.c',
+    link_with : [ libryu, libryu_printf ] )
+

--- a/ryu/tests/meson.build
+++ b/ryu/tests/meson.build
@@ -1,0 +1,16 @@
+# Build Ryu tests
+
+test_src = [
+    'd2s_intrinsics_test.cc',
+    'd2s_table_test.cc',
+    'd2s_test.cc',
+    'f2s_test.cc',
+    'd2fixed_test.cc',
+    'generic_128_test.cc',
+]
+
+testryu = executable('testryu', test_src,
+    include_directories : base_include_dir,
+    link_with : [ libryu, libryu_printf, libgen128, libgtest ] )
+
+test('all', testryu)

--- a/third_party/gtest/meson.build
+++ b/third_party/gtest/meson.build
@@ -1,0 +1,11 @@
+# Build gtest libs
+
+gtest_srcs = [
+    'gtest_main.cc',
+    'gtest-all.cc',
+]
+
+libgtest = library('gtest', gtest_srcs,
+    include_directories : base_include_dir,
+    dependencies : dependency('threads'))
+


### PR DESCRIPTION
This adds the possibility to build Ryu with meson.

The tests are included too.
And a small example as a quick how-to-use.

*(Just because I saw that `Makefile`-PR and we added meson support quite some time ago already ;)*