### PR TITLE
common: Remove superfluous assert

### DIFF
--- a/ryu/common.h
+++ b/ryu/common.h
@@ -30,7 +30,6 @@ static inline uint32_t decimalLength9(const uint32_t v) {
   // Function precondition: v is not a 10-digit number.
   // (f2s: 9 digits are sufficient for round-tripping.)
   // (d2fixed: We print 9-digit blocks.)
-  assert(v >= 0);
   assert(v < 1000000000);
   if (v >= 100000000) { return 9; }
   if (v >= 10000000) { return 8; }


### PR DESCRIPTION
[why]
Modern compilers issue a warning, if you try to compare an unsigned
number with >=0, as this is always true. Unsigned ints can not carry
negative values.

[how]
Remove the assert and believe the type.

Signed-off-by: Fini Jastrow <ulf.fini.jastrow@desy.de>