### PR TITLE
Make Ryu "to shortest" mode compatible with double-conversion

### DIFF
--- a/ryu/common.h
+++ b/ryu/common.h
@@ -85,18 +85,18 @@ static inline uint32_t log10Pow5(const int32_t e) {
 
 static inline int copy_special_str(char * const result, const bool sign, const bool exponent, const bool mantissa) {
   if (mantissa) {
-    memcpy(result, "NaN", 3);
+    memcpy(result, "nan", 3);
     return 3;
   }
   if (sign) {
     result[0] = '-';
   }
   if (exponent) {
-    memcpy(result + sign, "Infinity", 8);
-    return sign + 8;
+    memcpy(result + sign, "inf", 3);
+    return sign + 3;
   }
-  memcpy(result + sign, "0E0", 3);
-  return sign + 3;
+  memcpy(result + sign, "0", 1);
+  return sign + 1;
 }
 
 static inline uint32_t float_to_bits(const float f) {

--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -445,19 +445,16 @@ static inline int to_chars(const floating_decimal_32 v, const bool sign, char* c
   // Print the exponent.
   result[index++] = 'e';
 
-  if (exp)
-  {
-    if (exp < 0) {
-        result[index++] = '-';
-        exp = -exp;
-    }
+  if (exp < 0) {
+    result[index++] = '-';
+    exp = -exp;
+  }
 
-    if (exp >= 10) {
-        memcpy(result + index, DIGIT_TABLE + 2 * exp, 2);
-        index += 2;
-    } else {
-        result[index++] = (char) ('0' + exp);
-    }
+  if (exp >= 10) {
+    memcpy(result + index, DIGIT_TABLE + 2 * exp, 2);
+    index += 2;
+  } else {
+    result[index++] = (char) ('0' + exp);
   }
 
   return index;

--- a/ryu/f2s.c
+++ b/ryu/f2s.c
@@ -444,7 +444,6 @@ static inline int to_chars(const floating_decimal_32 v, const bool sign, char* c
 
   // Print the exponent.
   result[index++] = 'e';
-  int32_t exp = v.exponent + (int32_t) olength - 1;
 
   if (exp)
   {


### PR DESCRIPTION
This implementation is slightly suboptimal but still wins over double-conversion.