### PR TITLE
Add missing //ryu:ryu source file to Bazel target

### DIFF
--- a/ryu/BUILD
+++ b/ryu/BUILD
@@ -5,6 +5,7 @@ cc_library(
   srcs = [
     "f2s.c",
     "f2s_full_table.h",
+    "f2s_intrinsics.h",
     "d2s.c",
     "d2fixed.c",
     "d2fixed_full_table.h",


### PR DESCRIPTION
`bazel build //ryu:ryu` fails without this on my machine, and is failing in Travis as well.
https://travis-ci.org/github/ulfjack/ryu/jobs/691003011#L283

```console
ryu/f2s.c:35:10: fatal error: ryu/f2s_intrinsics.h: No such file or directory
   35 | #include "ryu/f2s_intrinsics.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
Target //ryu:ryu failed to build
```