### PR TITLE
Add manual pages

### DIFF
--- a/ryu/Makefile
+++ b/ryu/Makefile
@@ -24,15 +24,15 @@ libs: $(ALIB)
 
 .PHONY: install
 install: libs
-	mkdir -p $(DESTDIR)$(PREFIX)/lib
-	mkdir -p $(DESTDIR)$(PREFIX)/include
-	cp $(ALIB) $(DESTDIR)$(PREFIX)/lib/$(ALIB)
-	cp ryu.h $(DESTDIR)$(PREFIX)/include/
+	install -m 644 -d -- $(ALIB) $(DESTDIR)$(PREFIX)/lib/
+	install -m 644 -d -- ryu.h $(DESTDIR)$(PREFIX)/include/
+	install -m 644 -d -- man/* $(DESTDIR)$(PREFIX)/share/man/
 
 .PHONY: uninstall
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/lib/$(ALIB)
 	rm -f $(DESTDIR)$(PREFIX)/include/ryu.h
+	rm -rf $(DESTDIR)$(PREFIX)/share/man/
 
 TESTSRC=tests/common_test.cc tests/d2fixed_test.cc tests/d2s_intrinsics_test.cc tests/d2s_table_test.cc tests/d2s_test.cc tests/f2s_test.cc tests/generic_128_test.cc
 

--- a/ryu/man/ryu.3
+++ b/ryu/man/ryu.3
@@ -1,0 +1,91 @@
+.\" Please update the date every time you change the doc!
+.Dd October 15, 2020
+.Dt ryu	3
+.Os
+.Sh NAME
+.Nm ryu ,
+.Nm d2s ,
+.Nm d2s_buffered ,
+.Nm d2s_buffered_n ,
+.Nm f2s ,
+.Nm f2s_buffered ,
+.Nm f2s_buffered_n ,
+.Nm d2fixed ,
+.Nm d2fixed_buffered ,
+.Nm d2fixed_buffered_n ,
+.Nm d2exp ,
+.Nm d2exp_buffered ,
+.Nm d2exp_buffered_n
+.Nd convert floats to decimal strings
+.Sh LIBRARY
+.Lb libryu
+.Sh SYNOPSIS
+.In ryu.h
+.Ft "char *"
+.Fn d2s "double f"
+.Ft "void"
+.Fn d2s_buffered "double f, char* result"
+.Ft "int"
+.Fn d2s_buffered_n "double f, char* result"
+.Ft "char *"
+.Fn f2s "float f"
+.Ft "void"
+.Fn f2s_buffered "float f, char* result"
+.Ft "int"
+.Fn f2s_buffered_n "float f, char* result"
+.Ft "char *"
+.Fn d2fixed "double f"
+.Ft "void"
+.Fn d2fixed_buffered "double f, char* result"
+.Ft "int"
+.Fn d2fixed_buffered_n "double f, char* result"
+.Ft "char *"
+.Fn d2exp "double f"
+.Ft "void"
+.Fn d2exp_buffered "double f, char* result"
+.Ft "int"
+.Fn d2exp_buffered_n "double f, char* result"
+.Sh DESCRIPTION
+The functions convert IEEE-754 floating-point numbers to decimal strings using
+shortest, fixed, or scientific formatting.
+.Ss BEHAVIOR AND RETURN VALUE
+.Bl -bullet
+.It
+The functions returning
+.Ft "char *"
+simply provide a pointer to a null-terminated string in a buffer created by
+.Xr malloc 3 .
+.It
+The functions returning
+.Ft "void"
+fills the given buffer with a null-terminated string.
+.It
+The functions returning
+.Ft "int"
+fills the given buffer with a non-terminated string, returning the number of
+characters written.
+.El
+.Ss OUTPUT FORMATS
+.Bl -tag
+.It Shortest
+Used by
+.Fn d2s
+and
+.Fn f2s .
+The shortest representation that can be parsed into the same number of the same
+precision.
+.It Fixed
+Used by
+.Fn d2fixed .
+Fixed-point notation, as in
+.Ql %f .
+.It Scientific
+Used by
+.Fn d2exp .
+Scientific notation, as in 
+.Ql %e .
+.El
+.Sh SEE ALSO
+.Xr printf 3
+.Xr ryu_generic_128 3
+.Xr ryu_parse 3

--- a/ryu/man/ryu_generic_128.3
+++ b/ryu/man/ryu_generic_128.3
@@ -1,0 +1,31 @@
+.\" Please update the date every time you change the doc!
+.Dd October 15, 2020
+.Dt ryu_generic_128	3
+.Os
+.Sh NAME
+.Nm ryu_generic_128 ,
+.Nm s2d ,
+.Nm s2d_n ,
+.Nm s2f ,
+.Nd convert arbitrary-sized floats to decimal
+.Sh LIBRARY
+.Lb libryu
+.Sh SYNOPSIS
+.In ryu_generic_128.h
+.Vt struct floating_decimal_128
+{
+.D1 Fa "__uint128_t mantissa" ;
+.D1 Fa "int32_t exponent" ;
+.D1 Fa "bool sign" ;
+};
+
+.\" TODO
+.Sh DESCRIPTION
+.Nm
+extends
+.Xr ryu 3
+to handle much larger floating-point sizes. It is accordingly slower.
+.Sh SEE ALSO
+.Xr printf 3
+.Xr ryu 3
+.Xr ryu_parse 3

--- a/ryu/man/ryu_parse.3
+++ b/ryu/man/ryu_parse.3
@@ -1,0 +1,33 @@
+.\" Please update the date every time you change the doc!
+.Dd October 15, 2020
+.Dt ryu_parse	3
+.Os
+.Sh NAME
+.Nm ryu_parse ,
+.Nm s2d ,
+.Nm s2d_n ,
+.Nm s2f ,
+.Nd convert decimal strings to floats
+.Sh LIBRARY
+.Lb libryu
+.Sh SYNOPSIS
+.In ryu_parse.h
+.Vt enum Status
+{
+.D1 Dv SUCCESS ,
+.D1 Dv INPUT_TOO_SHORT ,
+.D1 Dv INPUT_TOO_LONG ,
+.D1 Dv MALFORMED_INPUT
+};
+
+.\" TODO
+.Sh DESCRIPTION
+.Nm
+parses a decimal string of limited length (17) to a floating-point value,
+using an algorithm based on 
+.Xr ryu 3 .
+It is not yet able to handle all formats.
+.Sh SEE ALSO
+.Xr printf 3
+.Xr ryu_generic_128 3
+.Xr ryu 3


### PR DESCRIPTION
As hated as they are, manpages are still quite commonly used by \*nix
programmers writing code. Given how semantic mdoc can be, it's not
*that* painful to write and consume nowadays.

I am not saying we should not add doxygen comments to the headers.