### PR TITLE
D Ryu implementation reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Other implementations of Ryu:
 | Go               | Caleb Spare        | https://github.com/cespare/ryu                |
 | C++              | Cqwrteur           | https://github.com/expnkx/fast_io             |
 | C#               | Dogwei             | https://github.com/Dogwei/RyuCsharp           |
+| D                | Ilya Yaroshenko    | [https://github.com/libmir/mir-algorithm][5]  |
 | Scala            | Denys Shabalin     | [https://github.com/scala-native/scala-native][4] |
 
 
@@ -99,6 +100,8 @@ Other implementations of Ryu:
 [3]: https://github.com/plokhotnyuk/jsoniter-scala/blob/6e6bb9d7bed6de341ce0b781b403eb671d008468/jsoniter-scala-core/jvm/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/core/JsonWriter.scala#L1777-L2262
 
 [4]: https://github.com/scala-native/scala-native/tree/master/nativelib/src/main/scala/scala/scalanative/runtime/ieee754tostring/ryu
+
+[5]: https://github.com/libmir/mir-algorithm/tree/master/source/mir/bignum/internal/ryu
 
 ## Ryu Printf
 Since Ryu generates the shortest decimal representation, it is not immediately


### PR DESCRIPTION
Hi Ulf,

Thank you for the great algorithm!

#### Mir/Dlang ryu port

We have only generic implementation for now.

Additional optimizations were applied:

1. Mir fixed-length integers `UInt!128` and `UInt!256`  are used instead of C's `uint128` and manual `ulong[4]` (for `uint256`). They were implemented with LLVM intrinsics and generates ideal (or almost ideal) code for multiplications.
2. /= and %= 10 operations are fused where possible and implemented using multiplication. C's `uint128` doesn't support this kind of optimization for now and performs the actual call of divide function.
3. `UInt!64` is used for `UInt!128 for `double` and `float`, all this reduces instructions size a lot.
4. #188 + minor additional optimization
5. A modification similar to #156
6. decimal length isn't used at all. Instead, we print the number to the buffer and return its position in the buffer. In a practical case, this would work faster. Mir/D's printing routines get this buffer size and copy it to the actual string appender (or Mir's stack-allocated `SmallString`).