### PR TITLE
d2s.c to_char scoping mutations

### DIFF
--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -318,7 +318,7 @@ static inline int to_chars(const floating_decimal_64 v, const bool sign, char* c
     result[index++] = '-';
   }
 
-  uint64_t output = v.mantissa;
+  const uint64_t output = v.mantissa;
   const uint32_t olength = decimalLength17(output);
 
 #ifdef RYU_DEBUG
@@ -336,56 +336,62 @@ static inline int to_chars(const floating_decimal_64 v, const bool sign, char* c
   // result[index] = '0' + output % 10;
 
   uint32_t i = 0;
-  // We prefer 32-bit operations, even on 64-bit platforms.
-  // We have at most 17 digits, and uint32_t can store 9 digits.
-  // If output doesn't fit into uint32_t, we cut off 8 digits,
-  // so the rest will fit into uint32_t.
-  if ((output >> 32) != 0) {
-    // Expensive 64-bit division.
-    const uint64_t q = div1e8(output);
-    uint32_t output2 = ((uint32_t) output) - 100000000 * ((uint32_t) q);
-    output = q;
+  {
+    // only i and result are mutated in this block
+    uint32_t output2 = (uint32_t) output;
+    const int indexC = index;
+    // const int indexOC = result + indexC + olength;
+    char* const indexROC = result + indexC + olength;
+    // We prefer 32-bit operations, even on 64-bit platforms.
+    // We have at most 17 digits, and uint32_t can store 9 digits.
+    // If output doesn't fit into uint32_t, we cut off 8 digits,
+    // so the rest will fit into uint32_t.
+    if ((output >> 32) != 0) {
+      // Expensive 64-bit division.
+      const uint64_t q = div1e8(output);
+      output2 = ((uint32_t) output) - 100000000 * ((uint32_t) q);
 
-    const uint32_t c = output2 % 10000;
-    output2 /= 10000;
-    const uint32_t d = output2 % 10000;
-    const uint32_t c0 = (c % 100) << 1;
-    const uint32_t c1 = (c / 100) << 1;
-    const uint32_t d0 = (d % 100) << 1;
-    const uint32_t d1 = (d / 100) << 1;
-    memcpy(result + index + olength - i - 1, DIGIT_TABLE + c0, 2);
-    memcpy(result + index + olength - i - 3, DIGIT_TABLE + c1, 2);
-    memcpy(result + index + olength - i - 5, DIGIT_TABLE + d0, 2);
-    memcpy(result + index + olength - i - 7, DIGIT_TABLE + d1, 2);
-    i += 8;
-  }
-  uint32_t output2 = (uint32_t) output;
-  while (output2 >= 10000) {
+      const uint32_t c = output2 % 10000;
+      const uint32_t d = (output2 / 10000) % 10000;
+      const uint32_t c0 = (c % 100) << 1;
+      const uint32_t c1 = (c / 100) << 1;
+      const uint32_t d0 = (d % 100) << 1;
+      const uint32_t d1 = (d / 100) << 1;
+      memcpy(indexROC - 1, DIGIT_TABLE + c0, 2);
+      memcpy(indexROC - 3, DIGIT_TABLE + c1, 2);
+      memcpy(indexROC - 5, DIGIT_TABLE + d0, 2);
+      memcpy(indexROC - 7, DIGIT_TABLE + d1, 2);
+      i = 8;
+      output2 = (uint32_t) q;
+    }
+    while (output2 >= 10000) {
 #ifdef __clang__ // https://bugs.llvm.org/show_bug.cgi?id=38217
-    const uint32_t c = output2 - 10000 * (output2 / 10000);
+      const uint32_t c = output2 - 10000 * (output2 / 10000);
 #else
-    const uint32_t c = output2 % 10000;
+      const uint32_t c = output2 % 10000;
 #endif
-    output2 /= 10000;
-    const uint32_t c0 = (c % 100) << 1;
-    const uint32_t c1 = (c / 100) << 1;
-    memcpy(result + index + olength - i - 1, DIGIT_TABLE + c0, 2);
-    memcpy(result + index + olength - i - 3, DIGIT_TABLE + c1, 2);
-    i += 4;
-  }
-  if (output2 >= 100) {
-    const uint32_t c = (output2 % 100) << 1;
-    output2 /= 100;
-    memcpy(result + index + olength - i - 1, DIGIT_TABLE + c, 2);
-    i += 2;
-  }
-  if (output2 >= 10) {
-    const uint32_t c = output2 << 1;
-    // We can't use memcpy here: the decimal dot goes between these two digits.
-    result[index + olength - i] = DIGIT_TABLE[c + 1];
-    result[index] = DIGIT_TABLE[c];
-  } else {
-    result[index] = (char) ('0' + output2);
+      output2 /= 10000;
+      const uint32_t c0 = (c % 100) << 1;
+      const uint32_t c1 = (c / 100) << 1;
+      memcpy(indexROC - i - 1, DIGIT_TABLE + c0, 2);
+      memcpy(indexROC - i - 3, DIGIT_TABLE + c1, 2);
+      i += 4;
+    }
+    if (output2 >= 100) {
+      const uint32_t c = (output2 % 100) << 1;
+      output2 /= 100;
+      memcpy(indexROC - i - 1, DIGIT_TABLE + c, 2);
+      i += 2;
+    }
+    if (output2 >= 10) {
+      const uint32_t c = output2 << 1;
+      // We can't use memcpy here: the decimal dot goes between these two digits.
+      //result[indexOC - i] = DIGIT_TABLE[c + 1];
+      *(indexROC - i) = DIGIT_TABLE[c + 1];
+      result[indexC] = DIGIT_TABLE[c];
+    } else {
+      result[indexC] = (char) ('0' + output2);
+    }
   }
 
   // Print decimal point if needed.

--- a/ryu/d2s.c
+++ b/ryu/d2s.c
@@ -335,9 +335,9 @@ static inline int to_chars(const floating_decimal_64 v, const bool sign, char* c
   // }
   // result[index] = '0' + output % 10;
 
-  uint32_t i = 0;
   {
-    // only i and result are mutated in this block
+    // only i, output2, and *result are mutated in this block
+    uint32_t i = 0;
     uint32_t output2 = (uint32_t) output;
     const int indexC = index;
     // const int indexOC = result + indexC + olength;


### PR DESCRIPTION
translating this to haskell and it is useful to know where variables are mutated.
A large block had constant values for `index`.

Also, there was some strange assignments for `output2` which I tried to correct, but I am unsure if this will affect performance.

Please diff with --ignore-all-space to ignore the indent.