### PR TITLE
update CMake minimum version and let IntelLLVM build generic128

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.10)
 project(ryu VERSION 2.0 LANGUAGES C)
 include(GNUInstallDirs)
 
@@ -29,10 +29,10 @@ install(FILES ryu/ryu.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ryu)
 
 
 # generic_128
-# Only builds on GCC/Clang/Intel due to __uint128_t. No MSVC.
+# Only builds on GCC/Clang/Intel/IntelLLVM due to __uint128_t. No MSVC.
 if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang"
         OR "${CMAKE_C_COMPILER_ID}" STREQUAL "GNU"
-        OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Intel")
+        OR "${CMAKE_C_COMPILER_ID}" MATCHES "Intel")
 
     add_library(generic_128
             ryu/generic_128.c


### PR DESCRIPTION
I bumped the CMake version because the newest versions have dropped compatibility with CMake <3.5, and have deprecated <3.10.

Also, the LLVM-based Intel compilers (icx, icpx) have __uint128_t, so I've added a check for that.
